### PR TITLE
docs(readme): дерево архитектуры и честный парный прогон

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -105,13 +105,20 @@ humanizer-ru/
 │   ├── check_spec.py             # Agent Skills spec compliance
 │   ├── check_fixture_sources.py  # Fixture source verification
 │   ├── check_docs.py             # Documentation consistency checks
-│   ├── check_examples.py          # Before/After example honesty gate
-│   ├── check_budget.py            # Context budget vs the official spec
+│   ├── check_examples.py         # Before/After example honesty gate
+│   ├── check_budget.py           # Context budget vs the official spec
+│   ├── check_readme_parity.py    # RU/EN showcase parity and honesty
+│   ├── check_corpus.py           # Validation corpus regression
+│   ├── check_perf.py             # Expression speed on a large input
+│   ├── check_release.py          # Release archive build and verification
 │   └── count_style_markers.py    # Style marker counter for A/B runs
 ├── eval/
-│   ├── run_eval.py                # Neutral corpus any candidate skill can run
-│   ├── blind_eval.py              # Blind paired evaluation of the skill effect
-│   └── HOW-TO-RUN.md              # Evaluation protocol and metric boundaries
+│   ├── run_eval.py               # Neutral corpus any candidate skill can run
+│   ├── blind_eval.py             # Blind paired evaluation of the skill effect
+│   ├── HOW-TO-RUN.md             # Evaluation protocol and metric boundaries
+│   ├── runs/                     # Paired runs: 2026-07-26-baseline
+│   └── results/                  # Full run reports, including metrics that
+│                                 #   do not favour the skill
 ├── docs/REVIEW.md                 # Review policy: three classes of change
 ├── references/                   # Full pattern descriptions, fixtures, model fingerprints
 ├── research/                     # Protocols, raw model outputs, pilot results

--- a/README.md
+++ b/README.md
@@ -116,12 +116,17 @@ humanizer-ru/
 │   ├── check_docs.py             # Согласованность документации
 │   ├── check_examples.py         # Гейт честности примеров До/После
 │   ├── check_readme_parity.py    # Паритет и правдивость витрины RU/EN
-│   └── check_budget.py           # Бюджет контекста по спецификации
+│   ├── check_budget.py           # Бюджет контекста по спецификации
+│   ├── check_corpus.py           # Регрессия корпусов валидации
+│   ├── check_perf.py             # Скорость выражений на большом входе
+│   └── check_release.py          # Сборка и проверка релизного архива
 ├── eval/
 │   ├── run_eval.py               # Нейтральный корпус для любого скилла
 │   ├── blind_eval.py             # Слепая парная оценка эффекта
 │   ├── HOW-TO-RUN.md             # Протокол прогона и границы метрик
-│   └── runs/README.md            # Реальных парных прогонов пока нет
+│   ├── runs/                     # Парные прогоны: 2026-07-26-baseline
+│   └── results/                  # Отчёты прогонов целиком, включая
+│                                 #   метрики не в пользу скилла
 ├── docs/REVIEW.md            # Регламент review: три класса изменений
 ├── .github/workflows/        # CI: regex-check, self-scan, no-anglicisms,
 │                             #     validators, docs-check, release-check


### PR DESCRIPTION
Два фикса README после v3.7.0. (1) Дерево архитектуры перечисляло 8 скриптов из 11 — добавлены check_corpus.py, check_perf.py, check_release.py; EN-версия 7→11. (2) Подпись «Реальных парных прогонов пока нет» стала неправдой — парный прогон опубликован в v3.7.0, формулировка заменена на факт. Все гейты зелёные: docs 23/23, readme_parity 11/11, markers 38/38, parity 38/38, perf 8/8, release 13/13. Тело релиза v3.7.0 не трогается (post-publication).