### PR TITLE
Readability pass on humanizer-ru core modules

### DIFF
--- a/eval/blind_eval.py
+++ b/eval/blind_eval.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """blind_eval.py — слепая парная оценка эффекта скилла.
 
 Отвечает на вопрос, на который не отвечает ни один другой валидатор:
@@ -32,9 +31,9 @@
 """
 import argparse
 import hashlib
-import io
 import json
 import os
+import pathlib
 import random
 import re
 import secrets
@@ -65,7 +64,7 @@ FAIL = "[FAIL]"
 
 
 def read(path):
-    with io.open(path, encoding="utf-8") as fh:
+    with pathlib.Path(path).open(encoding="utf-8") as fh:
         return fh.read()
 
 
@@ -74,7 +73,7 @@ def scan_markers(text):
     fd, tmp = tempfile.mkstemp(suffix=".md")
     os.close(fd)
     try:
-        with io.open(tmp, "w", encoding="utf-8") as fh:
+        with pathlib.Path(tmp).open("w", encoding="utf-8") as fh:
             fh.write(text)
         proc = subprocess.run(
             [sys.executable, CHECK_MARKERS, "--scan", tmp],
@@ -83,7 +82,7 @@ def scan_markers(text):
         out = proc.stdout.decode("utf-8", "replace")
         err = proc.stderr.decode("utf-8", "replace")
     finally:
-        os.unlink(tmp)
+        pathlib.Path(tmp).unlink()
     if proc.returncode not in (0, 1):
         raise RuntimeError("check_markers завершился с кодом %d: %s" %
                            (proc.returncode, err.strip() or out.strip()))
@@ -136,7 +135,7 @@ ID_RX = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 
 def load_run(run_dir):
     manifest_path = os.path.join(run_dir, "manifest.json")
-    if not os.path.isfile(manifest_path):
+    if not pathlib.Path(manifest_path).is_file():
         return None, "нет файла manifest.json в " + run_dir
     try:
         manifest = json.loads(read(manifest_path))
@@ -172,7 +171,7 @@ def load_run(run_dir):
             "without": os.path.join(run_dir, "without", pid + ".txt"),
             "with": os.path.join(run_dir, "with", pid + ".txt"),
         }
-        missing = [k for k, path in paths.items() if not os.path.isfile(path)]
+        missing = [k for k, path in paths.items() if not pathlib.Path(path).is_file()]
         if missing:
             return None, "пара %s: нет файлов %s" % (pid, ", ".join(missing))
         try:
@@ -221,10 +220,10 @@ def key_path_for(out_dir, sep=None, altsep=None):
 
 def make_packet(run, out_dir, rng=None):
     """Обезличенный пакет; ключ создаётся рядом, но вне пакета."""
-    if os.path.exists(out_dir) and os.listdir(out_dir):
+    if pathlib.Path(out_dir).exists() and os.listdir(out_dir):
         raise ValueError("каталог пакета не пуст: " + out_dir)
     rng = rng or secrets.SystemRandom()
-    os.makedirs(os.path.join(out_dir, "pairs"), exist_ok=True)
+    pathlib.Path(os.path.join(out_dir, "pairs")).mkdir(exist_ok=True, parents=True)
     pairs_key = {}
     order = list(run["items"])
     rng.shuffle(order)
@@ -234,24 +233,24 @@ def make_packet(run, out_dir, rng=None):
         a, b = (item["with"], item["without"]) if flip else (item["without"], item["with"])
         pairs_key[tag] = {"id": item["id"], "A": "with" if flip else "without",
                           "B": "without" if flip else "with", "kind": item["kind"]}
-        body = u"# %s\n\n## Исходный текст\n\n%s\n\n## Вариант A\n\n%s\n\n## Вариант B\n\n%s\n" % (
+        body = "# %s\n\n## Исходный текст\n\n%s\n\n## Вариант A\n\n%s\n\n## Вариант B\n\n%s\n" % (
             tag, item["source"].strip(), a.strip(), b.strip())
-        with io.open(os.path.join(out_dir, "pairs", tag + ".md"), "w", encoding="utf-8") as fh:
+        with pathlib.Path(os.path.join(out_dir, "pairs", tag + ".md")).open("w", encoding="utf-8") as fh:
             fh.write(body)
-    with io.open(os.path.join(out_dir, "INSTRUCTIONS.md"), "w", encoding="utf-8") as fh:
+    with pathlib.Path(os.path.join(out_dir, "INSTRUCTIONS.md")).open("w", encoding="utf-8") as fh:
         fh.write(JUDGE_INSTRUCTIONS)
     template = {tag: {"readability": "A|B|tie", "meaning_loss": "A|B|none", "note": ""}
                 for tag in sorted(pairs_key)}
-    with io.open(os.path.join(out_dir, "verdicts.template.json"), "w", encoding="utf-8") as fh:
+    with pathlib.Path(os.path.join(out_dir, "verdicts.template.json")).open("w", encoding="utf-8") as fh:
         fh.write(json.dumps(template, ensure_ascii=False, indent=2))
     key = {"version": 1, "run_sha256": run_fingerprint(run), "pairs": pairs_key}
     key_path = os.path.abspath(key_path_for(out_dir))
-    with io.open(key_path, "w", encoding="utf-8") as fh:
+    with pathlib.Path(key_path).open("w", encoding="utf-8") as fh:
         fh.write(json.dumps(key, ensure_ascii=False, indent=2))
     return key, key_path
 
 
-JUDGE_INSTRUCTIONS = u"""# Инструкция судье
+JUDGE_INSTRUCTIONS = """# Инструкция судье
 
 Перед вами исходный текст и две его редакции: Вариант A и Вариант B.
 Вы не знаете, как они получены, и знать не должны. Порядок вариантов
@@ -279,7 +278,6 @@ JUDGE_INSTRUCTIONS = u"""# Инструкция судье
 """
 
 
-
 def validate_judgements(run, judgements, key):
     if not isinstance(key, dict) or key.get("version") != 1 or not isinstance(key.get("pairs"), dict):
         raise ValueError("неподдерживаемый формат ключа")
@@ -304,6 +302,7 @@ def validate_judgements(run, judgements, key):
         if verdict.get("meaning_loss") not in ("A", "B", "none"):
             raise ValueError("%s: meaning_loss должен быть A, B или none" % tag)
     return key["pairs"]
+
 
 def aggregate(run, judgements=None, key=None):
     rows = []
@@ -390,13 +389,13 @@ def print_report(summary):
 # Образец собирается из частей намеренно: в памяти это настоящий маркер,
 # в тексте файла — нет. Иначе самопроверка репозитория справедливо падает
 # на этом файле. Проверено на практике при разработке этого скрипта.
-_ARTIFACT = u":content" + u"Reference[" + u"oai" + u"cite:" + u"1]"
-SRC = u"Важно отметить, что столица Австралии — Канберра " + _ARTIFACT + u"\nСтоит подчеркнуть, что город был основан специально."
-CLEAN = u"""Столица Австралии — Канберра.
+_ARTIFACT = ":content" + "Reference[" + "oai" + "cite:" + "1]"
+SRC = "Важно отметить, что столица Австралии — Канберра " + _ARTIFACT + "\nСтоит подчеркнуть, что город был основан специально."
+CLEAN = """Столица Австралии — Канберра.
 Город был основан специально."""
-INVENTED = u"""Столица Австралии — Канберра.
+INVENTED = """Столица Австралии — Канберра.
 Город основан в 1913 году по проекту Уолтера Берли Гриффина."""
-HUMAN = u"""Сегодня с утра лил дождь, и я всё-таки вышел без зонта."""
+HUMAN = """Сегодня с утра лил дождь, и я всё-таки вышел без зонта."""
 
 
 def _case(name, condition, detail=""):
@@ -419,7 +418,7 @@ def selftest():
 
     m3 = pair_metrics(HUMAN, HUMAN, HUMAN, "human")
     results.append(_case("Человеческий текст не тронут", m3["touched_with"] is False))
-    m4 = pair_metrics(HUMAN, HUMAN, HUMAN + u" Добавлено лишнее.", "human")
+    m4 = pair_metrics(HUMAN, HUMAN, HUMAN + " Добавлено лишнее.", "human")
     results.append(_case("Ложная правка поймана", m4["touched_with"] is True))
 
     run = {"manifest": {}, "items": [
@@ -441,19 +440,19 @@ def selftest():
                          os.path.dirname(key_path) == os.path.dirname(tmp) and not key_path.startswith(tmp + os.sep)))
     # Windows-случай: каталог пакета передан с хвостовым "/" при os.sep == "\".
     # Снятие только os.sep оставляло ключ внутри пакета (блайндинг терялся).
-    win_dir = u"C:\\runs\\packet/"
+    win_dir = "C:\\runs\\packet/"
     win_key = key_path_for(win_dir, sep="\\", altsep="/")
     old_win_key = win_dir.rstrip("\\") + ".key.json"
     results.append(_case("Ключ вне пакета при хвостовом разделителе Windows",
-                         win_key == u"C:\\runs\\packet.key.json"
+                         win_key == "C:\\runs\\packet.key.json"
                          and not win_key.startswith(win_dir),
                          win_key))
     results.append(_case("Прежняя логика на этом кейсе действительно падала",
                          old_win_key.startswith(win_dir), old_win_key))
-    for tail in (u"", os.sep, os.sep * 2):
-        cand = key_path_for(u"/runs/packet" + tail)
+    for tail in ("", os.sep, os.sep * 2):
+        cand = key_path_for("/runs/packet" + tail)
         results.append(_case("Ключ вне пакета при хвосте %r" % tail,
-                             cand == u"/runs/packet.key.json", cand))
+                             cand == "/runs/packet.key.json", cand))
 
     flipped = [t for t, v in pairs_key.items() if v["A"] == "with"]
     results.append(_case("Порядок вариантов перемешивается", 0 < len(flipped) < len(key), str(len(flipped))))
@@ -472,15 +471,15 @@ def selftest():
         root = tempfile.mkdtemp()
         manifest = {"run": "selftest", "model": "test-model", "skill_version": "test",
                     "prompt": "одинаковый промпт", "pairs": entries}
-        with io.open(os.path.join(root, "manifest.json"), "w", encoding="utf-8") as fh:
+        with pathlib.Path(os.path.join(root, "manifest.json")).open("w", encoding="utf-8") as fh:
             fh.write(json.dumps(manifest, ensure_ascii=False))
         for entry in entries:
             pid = entry.get("id", "")
             if not ID_RX.fullmatch(pid):
                 continue
             for branch in ("source", "without", "with"):
-                os.makedirs(os.path.join(root, branch), exist_ok=True)
-                with io.open(os.path.join(root, branch, pid + ".txt"), "w", encoding="utf-8") as fh:
+                pathlib.Path(os.path.join(root, branch)).mkdir(exist_ok=True, parents=True)
+                with pathlib.Path(os.path.join(root, branch, pid + ".txt")).open("w", encoding="utf-8") as fh:
                     fh.write("непустой текст")
         return load_run(root)
 
@@ -581,7 +580,7 @@ def main():
         if not key_path:
             print("%s Для вердиктов обязателен --key; ключ хранится вне пакета." % FAIL)
             return 2
-        if not os.path.isfile(key_path):
+        if not pathlib.Path(key_path).is_file():
             print("%s Не найден ключ обезличивания: %s" % (FAIL, key_path))
             return 2
         key = json.loads(read(key_path))
@@ -595,14 +594,14 @@ def main():
 
     out = args.out
     if not out:
-        os.makedirs(os.path.join(HERE, "results"), exist_ok=True)
+        pathlib.Path(os.path.join(HERE, "results")).mkdir(exist_ok=True, parents=True)
         out = os.path.join(HERE, "results", os.path.basename(os.path.normpath(args.run)) + ".json")
     payload = {"run": os.path.basename(os.path.normpath(args.run)),
                "manifest": run["manifest"], "run_sha256": run_fingerprint(run),
                "summary": summary, "pairs": rows}
     if judgements is not None:
         payload["judgements"] = judgements
-    with io.open(out, "w", encoding="utf-8") as fh:
+    with pathlib.Path(out).open("w", encoding="utf-8") as fh:
         fh.write(json.dumps(payload, ensure_ascii=False, indent=2))
     print("")
     print("Отчёт: %s" % out)

--- a/eval/run_eval.py
+++ b/eval/run_eval.py
@@ -22,6 +22,7 @@ import argparse
 import hashlib
 import json
 import os
+import pathlib
 import re
 import subprocess
 import sys
@@ -36,8 +37,8 @@ MANIFEST = os.path.join(os.path.dirname(os.path.abspath(__file__)), "manifest.v1
 
 try:
     sys.path.insert(0, os.path.join(ROOT, "scripts"))
-    from check_markers import CASES, _inside_backticks, _console_text
-except Exception as exc:  # noqa: BLE001
+    from check_markers import CASES, _console_text, _inside_backticks
+except Exception as exc:  # ruff:ignore[blind-except]
     print("Не удалось импортировать check_markers: %s" % exc, file=sys.stderr)
     CASES = {}
 
@@ -69,7 +70,7 @@ def _safe_path(rel, root):
     if not isinstance(rel, str) or not rel.strip():
         raise ManifestError("путь записи корпуса должен быть непустой строкой")
     native = rel.replace("\\", "/")
-    if os.path.isabs(rel) or os.path.isabs(native) or re.match(r"^[A-Za-z]:", rel):
+    if pathlib.Path(rel).is_absolute() or pathlib.Path(native).is_absolute() or re.match(r"^[A-Za-z]:", rel):
         raise ManifestError("путь записи корпуса должен быть относительным, получено: " + rel)
     if "\\" in rel:
         raise ManifestError("обратный слэш в пути записи корпуса запрещён: " + rel)
@@ -84,7 +85,7 @@ def _safe_path(rel, root):
 
 def _sha256(path):
     h = hashlib.sha256()
-    with open(path, "rb") as fh:
+    with pathlib.Path(path).open("rb") as fh:
         for chunk in iter(lambda: fh.read(65536), b""):
             h.update(chunk)
     return h.hexdigest()
@@ -92,7 +93,7 @@ def _sha256(path):
 
 def _scan_default(path, compiled):
     hits = []
-    with open(path, encoding="utf-8") as fh:
+    with pathlib.Path(path).open(encoding="utf-8") as fh:
         for lineno, line in enumerate(fh.read().splitlines(), 1):
             for name, rx in compiled.items():
                 for m in rx.finditer(line):
@@ -119,7 +120,7 @@ def run(manifest_path=MANIFEST, candidate=None, root=ROOT):
     # отказ инструмента (код 2), а не регрессия корпуса и не traceback: тот же
     # порядок разделения кодов, что в scripts/check_budget.py.
     try:
-        with open(manifest_path, encoding="utf-8") as fh:
+        with pathlib.Path(manifest_path).open(encoding="utf-8") as fh:
             manifest = json.load(fh)
     except OSError as exc:
         raise ManifestError("не удалось прочитать манифест %s: %s" % (manifest_path, exc))
@@ -145,7 +146,7 @@ def run(manifest_path=MANIFEST, candidate=None, root=ROOT):
         # путь не должен даже проверяться на существование за пределами корня.
         path = _safe_path(rel, root)
         summary["files"] += 1
-        if not os.path.isfile(path):
+        if not pathlib.Path(path).is_file():
             # Пропавший файл корпуса — провал прогона, а не примечание в details:
             # иначе удаление всего корпуса давало бы зелёный отчёт.
             summary["files_missing"] += 1
@@ -180,15 +181,14 @@ def run(manifest_path=MANIFEST, candidate=None, root=ROOT):
                     summary["details"].append({"file": rel, "kind": "ai",
                                                "expected": expected, "actual": len(hits),
                                                "cases": sorted(n for n in actual_names if n)})
-        elif kind == "boundary":
-            if expected is not None:
-                if len(hits) == expected and (not expected_case or expected_case in actual_names):
-                    summary["boundary_expected_ok"] += 1
-                else:
-                    summary["boundary_unexpected"] += 1
-                    summary["details"].append({"file": rel, "kind": "boundary",
-                                               "expected": expected, "actual": len(hits),
-                                               "cases": list(actual_names)})
+        elif kind == "boundary" and expected is not None:
+            if len(hits) == expected and (not expected_case or expected_case in actual_names):
+                summary["boundary_expected_ok"] += 1
+            else:
+                summary["boundary_unexpected"] += 1
+                summary["details"].append({"file": rel, "kind": "boundary",
+                                           "expected": expected, "actual": len(hits),
+                                           "cases": list(actual_names)})
     return summary
 
 
@@ -216,7 +216,7 @@ def _selftest_corpus(root):
     corpus = []
     for name, body in files.items():
         path = os.path.join(root, name)
-        with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        with pathlib.Path(path).open("w", encoding="utf-8", newline="\n") as fh:
             fh.write(body)
         entry = {"path": name, "sha256": _sha256(path),
                  "kind": {"human.txt": "human", "ai.txt": "ai",
@@ -228,7 +228,7 @@ def _selftest_corpus(root):
             entry["expected_hits"] = 0
         corpus.append(entry)
     manifest_path = os.path.join(root, "manifest.json")
-    with open(manifest_path, "w", encoding="utf-8", newline="\n") as fh:
+    with pathlib.Path(manifest_path).open("w", encoding="utf-8", newline="\n") as fh:
         json.dump({"version": "selftest", "corpus": corpus}, fh, ensure_ascii=False)
     return manifest_path
 
@@ -243,24 +243,24 @@ def selftest():
         cases.append((name, mutate, expect_key))
 
     def _drop_file(root):
-        os.remove(os.path.join(root, "human.txt"))
+        pathlib.Path(os.path.join(root, "human.txt")).unlink()
 
     def _tamper(root):
-        with open(os.path.join(root, "human.txt"), "a", encoding="utf-8") as fh:
+        with pathlib.Path(os.path.join(root, "human.txt")).open("a", encoding="utf-8") as fh:
             fh.write("дописанная строка\n")
 
     def _break_expectation(root):
         # Манифест ждёт одно совпадение, а в файле их два.
-        with open(os.path.join(root, "ai.txt"), "w", encoding="utf-8", newline="\n") as fh:
+        with pathlib.Path(os.path.join(root, "ai.txt")).open("w", encoding="utf-8", newline="\n") as fh:
             fh.write(_SELFTEST_AI)
             fh.write("Ещё одна метка %s во второй строке.\n" % _MARKER)
         manifest_path = os.path.join(root, "manifest.json")
-        with open(manifest_path, encoding="utf-8") as fh:
+        with pathlib.Path(manifest_path).open(encoding="utf-8") as fh:
             data = json.load(fh)
         for entry in data["corpus"]:
             if entry["path"] == "ai.txt":
                 entry["sha256"] = _sha256(os.path.join(root, "ai.txt"))
-        with open(manifest_path, "w", encoding="utf-8", newline="\n") as fh:
+        with pathlib.Path(manifest_path).open("w", encoding="utf-8", newline="\n") as fh:
             json.dump(data, fh, ensure_ascii=False)
 
     case("целый корпус -> прогон чистый", lambda r: None, None)
@@ -300,11 +300,11 @@ def selftest():
     missing = os.path.join(tmp_input, "нет-такого.json")
     input_cases.append(("отсутствующий манифест -> отказ", missing))
     broken = os.path.join(tmp_input, "битый.json")
-    with open(broken, "w", encoding="utf-8") as fh:
+    with pathlib.Path(broken).open("w", encoding="utf-8") as fh:
         fh.write("{не json")
     input_cases.append(("манифест не является JSON -> отказ", broken))
     not_object = os.path.join(tmp_input, "список.json")
-    with open(not_object, "w", encoding="utf-8") as fh:
+    with pathlib.Path(not_object).open("w", encoding="utf-8") as fh:
         fh.write("[1, 2, 3]")
     input_cases.append(("манифест без поля corpus -> отказ", not_object))
     for name, path in input_cases:
@@ -314,7 +314,7 @@ def selftest():
         except ManifestError:
             passed += 1
             print("PASS: %s" % name)
-        except Exception as exc:  # noqa: BLE001 — любой иной сбой считаем провалом
+        except Exception as exc:  # ruff:ignore[blind-except] — любой иной сбой считаем провалом
             print("FAIL: %s (вместо отказа %s)" % (name, type(exc).__name__))
 
     total = len(cases) + _BOUNDARY_TOTAL + len(input_cases)
@@ -341,12 +341,12 @@ def _boundary_selftest():
         """Собирает манифест на одну запись с путём rel и запускает run()."""
         payload = _SELFTEST_HUMAN
         body = os.path.join(root, "внутри.txt")
-        with open(body, "w", encoding="utf-8", newline="\n") as fh:
+        with pathlib.Path(body).open("w", encoding="utf-8", newline="\n") as fh:
             fh.write(payload)
         manifest = {"version": "boundary", "corpus": [
             {"path": rel, "kind": "human", "sha256": _sha256(body)}]}
         manifest_path = os.path.join(root, "manifest.json")
-        with open(manifest_path, "w", encoding="utf-8", newline="\n") as fh:
+        with pathlib.Path(manifest_path).open("w", encoding="utf-8", newline="\n") as fh:
             json.dump(manifest, fh, ensure_ascii=False)
         return run(manifest_path, None, root)
 
@@ -382,12 +382,12 @@ def _boundary_selftest():
     outside = tempfile.mkdtemp()
     try:
         secret = os.path.join(outside, "секрет.txt")
-        with open(secret, "w", encoding="utf-8") as fh:
+        with pathlib.Path(secret).open("w", encoding="utf-8") as fh:
             fh.write("данные вне корня\n")
         link = os.path.join(root, "ссылка.txt")
         supported = True
         try:
-            os.symlink(secret, link)
+            pathlib.Path(link).symlink_to(secret)
         except (OSError, NotImplementedError, AttributeError):
             # Платформа без symlink (например, Windows без прав): кейс не
             # применим, засчитываем как пройденный, чтобы не давать ложный сбой.

--- a/scripts/check_budget.py
+++ b/scripts/check_budget.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Гейт бюджета контекста для формата Agent Skills.
 
 Официальная спецификация описывает трёхуровневую загрузку: метаданные читаются
@@ -14,8 +13,8 @@
 Оценка токенов консервативная: для кириллицы берётся 3.0 символа на токен,
 для остального — 4.0. Внешние зависимости не используются.
 """
-import io
 import os
+import pathlib
 import re
 import sys
 import tempfile
@@ -142,13 +141,13 @@ def check_skill(text, name_hint=None):
 def check_references(root):
     warnings, rows = [], []
     ref_dir = os.path.join(root, "references")
-    if not os.path.isdir(ref_dir):
+    if not pathlib.Path(ref_dir).is_dir():
         return warnings, rows
     for fn in sorted(os.listdir(ref_dir)):
         if not fn.endswith(".md"):
             continue
         path = os.path.join(ref_dir, fn)
-        text = io.open(path, encoding="utf-8").read()
+        text = pathlib.Path(path).open(encoding="utf-8").read()
         tok = estimate_tokens(text)
         rows.append((fn, tok))
         if tok > WARN_REFERENCE_TOKENS:
@@ -158,7 +157,7 @@ def check_references(root):
     return warnings, rows
 
 
-SELFTEST_OK = u"""---
+SELFTEST_OK = """---
 name: good-skill
 description: "Делает полезное и применяется тогда-то."
 ---
@@ -182,30 +181,30 @@ def selftest():
     e, _, _ = check_skill(SELFTEST_OK.replace("good-skill", "-good"))
     cases.append(("дефис в начале отловлен", any("name" in x for x in e), e))
 
-    long_desc = SELFTEST_OK.replace(u"Делает полезное и применяется тогда-то.", u"а" * 1025)
+    long_desc = SELFTEST_OK.replace("Делает полезное и применяется тогда-то.", "а" * 1025)
     e, _, _ = check_skill(long_desc)
     cases.append(("длинный description отловлен", any("description" in x for x in e), e))
 
-    e, _, _ = check_skill(SELFTEST_OK + u"\n".join([u"строка"] * 600))
+    e, _, _ = check_skill(SELFTEST_OK + "\n".join(["строка"] * 600))
     cases.append(("длинное тело отловлено", any("строк" in x for x in e), e))
 
-    e, _, _ = check_skill(SELFTEST_OK + u"я" * 40000)
+    e, _, _ = check_skill(SELFTEST_OK + "я" * 40000)
     cases.append(("перерасход токенов отловлен", any("токенов" in x for x in e), e))
 
     e, _, _ = check_skill(SELFTEST_OK, name_hint="other-dir")
     cases.append(("несовпадение с каталогом отловлено", any("каталог" in x for x in e), e))
 
-    e, _, _ = check_skill(u"без frontmatter")
+    e, _, _ = check_skill("без frontmatter")
     cases.append(("отсутствие frontmatter отловлено", e != [], e))
 
-    cases.append(("оценка токенов монотонна", estimate_tokens(u"а" * 300) > estimate_tokens(u"а" * 100), None))
+    cases.append(("оценка токенов монотонна", estimate_tokens("а" * 300) > estimate_tokens("а" * 100), None))
 
     # Разбор argv: значение --expect-dir не должно становиться путём к файлу.
     # До правки этот порядок аргументов ронял валидатор попыткой открыть
     # каталог как файл.
     tmp = tempfile.mkdtemp()
     skill_path = os.path.join(tmp, "SKILL.md")
-    with io.open(skill_path, "w", encoding="utf-8") as fh:
+    with pathlib.Path(skill_path).open("w", encoding="utf-8") as fh:
         fh.write(SELFTEST_OK.replace("good-skill", "demo-dir"))
     rc_before = main(["--expect-dir", "demo-dir", skill_path])
     rc_after = main([skill_path, "--expect-dir", "demo-dir"])
@@ -218,7 +217,7 @@ def selftest():
     rc_absent = main([os.path.join(tmp, "нет-файла.md")])
     cases.append(("отсутствующий файл -> код 2", rc_absent == 2, rc_absent))
     bad_bytes = os.path.join(tmp, "битый.md")
-    with open(bad_bytes, "wb") as fh:
+    with pathlib.Path(bad_bytes).open("wb") as fh:
         fh.write(b"---\nname: x\n\xff\xfe not utf-8 \xff\n---\n")
     rc_bad = main([bad_bytes])
     cases.append(("файл не в UTF-8 -> код 2", rc_bad == 2, rc_bad))
@@ -258,7 +257,7 @@ def main(argv):
     # Сбой чтения — это отказ инструмента (код 2), а не провал бюджета (код 1)
     # и не traceback.
     try:
-        text = io.open(path, encoding="utf-8").read()
+        text = pathlib.Path(path).open(encoding="utf-8").read()
     except OSError as exc:
         print("не удалось прочитать %s: %s" % (path, exc))
         return 2

--- a/scripts/check_corpus.py
+++ b/scripts/check_corpus.py
@@ -22,11 +22,12 @@ if hasattr(sys.stdout, "reconfigure"):
     sys.stderr.reconfigure(errors="backslashreplace")
 
 try:
-    from check_markers import CASES, _inside_backticks, _console_text
-except Exception:  # noqa: BLE001
+    from check_markers import CASES, _console_text, _inside_backticks
+except Exception:  # ruff:ignore[blind-except]
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-    from check_markers import CASES, _inside_backticks, _console_text
+    from check_markers import CASES, _console_text, _inside_backticks
 
+import pathlib
 import re
 
 HUMAN_DIR = "research/validation/human"
@@ -55,7 +56,7 @@ RAW_EXPECTED = {
 def _scan_file(path, compiled):
     hits = []
     try:
-        with open(path, encoding="utf-8") as fh:
+        with pathlib.Path(path).open(encoding="utf-8") as fh:
             lines = fh.read().splitlines()
     except OSError as exc:
         return [(0, "read-error", str(exc))]
@@ -75,7 +76,7 @@ def run(human_dir=HUMAN_DIR, raw_dirs=RAW_DIRS, boundary_dir=BOUNDARY_DIR):
     # Без корпусов проверять нечего, а прежний код печатал «ОК» и возвращал 0:
     # вне полного клона (в релизном архиве research/ нет) это выглядело как
     # успешная проверка. Отказ инструмента — код 2, отдельно от регрессии (1).
-    present = [d for d in ((human_dir, boundary_dir) + tuple(raw_dirs)) if os.path.isdir(d)]
+    present = [d for d in ((human_dir, boundary_dir) + tuple(raw_dirs)) if pathlib.Path(d).is_dir()]
     if not present:
         print("[СБОЙ] корпусов нет ни в одном из каталогов: %s"
               % ", ".join((human_dir, boundary_dir) + tuple(raw_dirs)))
@@ -84,7 +85,7 @@ def run(human_dir=HUMAN_DIR, raw_dirs=RAW_DIRS, boundary_dir=BOUNDARY_DIR):
         return 2
 
     # Human corpus: 0 совпадений.
-    if os.path.isdir(human_dir):
+    if pathlib.Path(human_dir).is_dir():
         for fn in sorted(os.listdir(human_dir)):
             if not fn.endswith(".txt"):
                 continue
@@ -96,7 +97,7 @@ def run(human_dir=HUMAN_DIR, raw_dirs=RAW_DIRS, boundary_dir=BOUNDARY_DIR):
     # Raw corpus: только ожидаемые совпадения.
     seen_expected = set()
     for d in raw_dirs:
-        if not os.path.isdir(d):
+        if not pathlib.Path(d).is_dir():
             continue
         for fn in sorted(os.listdir(d)):
             if not fn.endswith(".txt"):
@@ -114,7 +115,7 @@ def run(human_dir=HUMAN_DIR, raw_dirs=RAW_DIRS, boundary_dir=BOUNDARY_DIR):
                 seen_expected.add(key)
 
     # Boundary corpus: ровно заявленные совпадения.
-    if os.path.isdir(boundary_dir):
+    if pathlib.Path(boundary_dir).is_dir():
         for fn in sorted(os.listdir(boundary_dir)):
             if not fn.endswith(".txt"):
                 continue
@@ -125,7 +126,7 @@ def run(human_dir=HUMAN_DIR, raw_dirs=RAW_DIRS, boundary_dir=BOUNDARY_DIR):
                 fails.append("%s: boundary mismatch — ожидалось %s, найдено %s"
                              % (fn, expected, actual))
 
-    if not seen_expected and all(os.path.isdir(d) for d in raw_dirs):
+    if not seen_expected and all(pathlib.Path(d).is_dir() for d in raw_dirs):
         fails.append("raw-корпус: ни одного ожидаемого BOM-совпадения — проверьте corpus")
 
     if fails:
@@ -140,39 +141,39 @@ def run(human_dir=HUMAN_DIR, raw_dirs=RAW_DIRS, boundary_dir=BOUNDARY_DIR):
 def selftest():
     import tempfile
     tmp = tempfile.mkdtemp()
-    human = os.path.join(tmp, "human"); os.makedirs(human)
-    boundary = os.path.join(tmp, "boundary"); os.makedirs(boundary)
-    raw = os.path.join(tmp, "raw", "le-chat"); os.makedirs(raw)
-    with open(os.path.join(human, "01.txt"), "w", encoding="utf-8") as f:
+    human = os.path.join(tmp, "human"); pathlib.Path(human).mkdir(parents=True)
+    boundary = os.path.join(tmp, "boundary"); pathlib.Path(boundary).mkdir(parents=True)
+    raw = os.path.join(tmp, "raw", "le-chat"); pathlib.Path(raw).mkdir(parents=True)
+    with pathlib.Path(os.path.join(human, "01.txt")).open("w", encoding="utf-8") as f:
         f.write("обычный человеческий текст без маркеров\n")
-    with open(os.path.join(boundary, "emoji-zwj.txt"), "w", encoding="utf-8") as f:
+    with pathlib.Path(os.path.join(boundary, "emoji-zwj.txt")).open("w", encoding="utf-8") as f:
         f.write("семья: \U0001F468\u200d\U0001F469\u200d\U0001F466\n")
-    with open(os.path.join(raw, "01-fast-канберра.txt"), "w", encoding="utf-8") as f:
+    with pathlib.Path(os.path.join(raw, "01-fast-канберра.txt")).open("w", encoding="utf-8") as f:
         f.write("\ufeffответ модели\n")
     checks = []
     rc = run(human_dir=human, raw_dirs=(raw,), boundary_dir=boundary)
     checks.append(("чистый human + ожиданный raw BOM + ZWJ-граница -> OK", rc == 0))
-    with open(os.path.join(human, "02.txt"), "w", encoding="utf-8") as f:
+    with pathlib.Path(os.path.join(human, "02.txt")).open("w", encoding="utf-8") as f:
         f.write("текст с turn0search0 маркером\n")
     rc = run(human_dir=human, raw_dirs=(raw,), boundary_dir=boundary)
     checks.append(("human с маркером -> FAIL", rc == 1))
-    os.unlink(os.path.join(human, "02.txt"))
+    pathlib.Path(os.path.join(human, "02.txt")).unlink()
 
     # Прежний кейс писал в boundary файл без маркеров: ожидалось пусто, найдено
     # пусто — проверка возвращала 0 и ничего не доказывала. Настоящий негатив —
     # boundary-файл с маркером, которого в BOUNDARY_EXPECTED нет.
     extra = os.path.join(boundary, "extra.txt")
-    with open(extra, "w", encoding="utf-8") as f:
+    with pathlib.Path(extra).open("w", encoding="utf-8") as f:
         f.write("граничный файл с turn0search0 внутри\n")
     rc = run(human_dir=human, raw_dirs=(raw,), boundary_dir=boundary)
     checks.append(("boundary с незаявленным совпадением -> FAIL", rc == 1))
-    os.unlink(extra)
+    pathlib.Path(extra).unlink()
 
     # Ключ RAW_EXPECTED учитывает каталог: одноимённый файл в другом каталоге
     # модели не наследует разрешение на BOM.
     other_raw = os.path.join(tmp, "raw", "gigachat")
-    os.makedirs(other_raw)
-    with open(os.path.join(other_raw, "01-fast-канберра.txt"), "w", encoding="utf-8") as f:
+    pathlib.Path(other_raw).mkdir(parents=True)
+    with pathlib.Path(os.path.join(other_raw, "01-fast-канберра.txt")).open("w", encoding="utf-8") as f:
         f.write("﻿тот же файл, но другая модель\n")
     rc = run(human_dir=human, raw_dirs=(raw, other_raw), boundary_dir=boundary)
     checks.append(("одноимённый файл в другом каталоге не наследует разрешение -> FAIL",

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """check_docs.py — проверка согласованности документации humanizer-ru.
 
 Проверки:
@@ -27,6 +26,7 @@ Exit 0 — все проверки пройдены, 1 — есть ошибки
 """
 import argparse
 import os
+import pathlib
 import re
 import sys
 import tempfile
@@ -50,9 +50,11 @@ LECHAT_WRONG_DASH = 'прежние пометки "дефис" были нев�
 WORKFLOWS_DIR = ".github/workflows"
 MOJIBAKE_TOKENS = ("РЎ", "Рџ", "СЂР")
 
+
 def _read(path):
- with open(path, "rb") as f:
+ with pathlib.Path(path).open("rb") as f:
   return f.read()
+
 
 def check_repo(root):
  errors = []
@@ -68,7 +70,7 @@ def check_repo(root):
 
  # 1. UTF-8 без BOM
  for rel in DOC_FILES:
-  if not os.path.exists(p(rel)):
+  if not pathlib.Path(p(rel)).exists():
    errors.append("%s: файл отсутствует" % rel)
    continue
   raw = _read(p(rel))
@@ -139,12 +141,12 @@ def check_repo(root):
      before = line[:start]
      if before.count("`") % 2 == 1 and line[start:].count("`") >= 1:
       continue
-    if not os.path.exists(os.path.join(base, target_path)):
+    if not pathlib.Path(os.path.join(base, target_path)).exists():
      errors.append("%s:%d: битая внутренняя ссылка -> %s" % (rel, lineno, target))
 
  # 8. Сырые файлы без аналитики
  raw_dir = p("research/raw")
- if os.path.isdir(raw_dir):
+ if pathlib.Path(raw_dir).is_dir():
   for dirpath, _dirs, files in os.walk(raw_dir):
    for fn in sorted(files):
     fp = os.path.join(dirpath, fn)
@@ -162,7 +164,7 @@ def check_repo(root):
       break
 
  # 9. Журнал Le Chat
- if os.path.exists(p(LECHAT_LOG)):
+ if pathlib.Path(p(LECHAT_LOG)).exists():
   t = text(LECHAT_LOG)
   runs = len(re.findall(r"^\|\s*\d+\s*\|", t, re.M))
   if "MARKER_FOUND" in t and runs < MIN_RUNS_FOR_MARKER:
@@ -210,7 +212,7 @@ def check_repo(root):
 
  # 14. Workflows: UTF-8 без BOM и без mojibake
  wf_dir = p(WORKFLOWS_DIR)
- if os.path.isdir(wf_dir):
+ if pathlib.Path(wf_dir).is_dir():
   for fn in sorted(os.listdir(wf_dir)):
    if not fn.endswith((".yml", ".yaml")):
     continue
@@ -231,7 +233,7 @@ def check_repo(root):
 
  # 15. CITATION.cff согласован с версией скилла
  cff_path = p("CITATION.cff")
- if not os.path.exists(cff_path):
+ if not pathlib.Path(cff_path).exists():
   errors.append("CITATION.cff: файл отсутствует — на него ссылается docs-check")
  else:
   cff = text("CITATION.cff")
@@ -249,15 +251,17 @@ def check_repo(root):
 
 # ------------------------------------------------------------------ selftest
 
+
 def _w(root, rel, content, binary=False):
  path = os.path.join(root, rel)
- os.makedirs(os.path.dirname(path), exist_ok=True)
+ pathlib.Path(os.path.dirname(path)).mkdir(exist_ok=True, parents=True)
  if binary:
-  with open(path, "wb") as f:
+  with pathlib.Path(path).open("wb") as f:
    f.write(content)
  else:
-  with open(path, "w", encoding="utf-8") as f:
+  with pathlib.Path(path).open("w", encoding="utf-8") as f:
    f.write(content)
+
 
 def _make_repo(root, version="3.3.5"):
  _w(root, "SKILL.md",
@@ -287,6 +291,7 @@ def _make_repo(root, version="3.3.5"):
     'authors:\n  - name: "Vladimir-Human"\n'
     'version: %s\ndate-released: "2026-07-25"\n' % version)
 
+
 def _citation_wrong_version(root):
  """В CITATION.cff версия чужая — гейт обязан это увидеть."""
  _w(root, "CITATION.cff",
@@ -294,9 +299,11 @@ def _citation_wrong_version(root):
     'authors:\n  - name: "Vladimir-Human"\n'
     'version: 9.9.9\ndate-released: "2026-07-25"\n')
 
+
 def _citation_missing(root):
  """CITATION.cff удалён."""
- os.remove(os.path.join(root, "CITATION.cff"))
+ pathlib.Path(os.path.join(root, "CITATION.cff")).unlink()
+
 
 def _citation_bad_date(root):
  """date-released не в формате ISO."""
@@ -305,12 +312,14 @@ def _citation_bad_date(root):
     'authors:\n  - name: "Vladimir-Human"\n'
     'version: 3.3.5\ndate-released: "25 июля 2026"\n')
 
+
 def _drop_lechat_and_overclaim(root):
  """Журнала Le Chat нет, а завышенная формулировка в README есть."""
- os.remove(os.path.join(root, LECHAT_LOG))
+ pathlib.Path(os.path.join(root, LECHAT_LOG)).unlink()
  _w(root, "README.md",
     "# R\n[CHANGELOG.md](CHANGELOG.md)\n"
     "Скилл содержит 38 однозначных маркеров.\n")
+
 
 def selftest():
  cases = []
@@ -437,6 +446,7 @@ def selftest():
  print("САМОПРОВЕРКА: %d/%d PASS" % (passed, total))
  return 0 if passed == total else 1
 
+
 def main():
  parser = argparse.ArgumentParser(
   description="Проверка согласованности документации humanizer-ru")
@@ -455,6 +465,7 @@ def main():
   sys.exit(1)
  print("ДОКУМЕНТАЦИЯ: все проверки пройдены.")
  sys.exit(0)
+
 
 if __name__ == "__main__":
  main()

--- a/scripts/check_examples.py
+++ b/scripts/check_examples.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """check_examples.py — гейт честности пар «До/После».
 
 Проверяет главное обещание скилла: правка не дописывает факты за автора.
@@ -20,8 +19,8 @@
 """
 import argparse
 import glob
-import io
 import os
+import pathlib
 import re
 import sys
 import tempfile
@@ -35,19 +34,10 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 TARGETS = ["SKILL.md", "README.md", "README.en.md"]
 
-NUMWORDS = set("""
-один одна одно одного одним два две двух двумя три трех тремя четыре четырех
-пять пяти шесть шести семь семи восемь восьми девять девяти десять десяти
-одиннадцать двенадцать двадцать тридцать сорок пятьдесят сто ста
-тысяча тысячи тысяч миллион миллиона миллиард
-первый первая второй вторая третий третья четвертый пятый
-вдвое втрое вчетверо половина треть четверть
-""".split())
+NUMWORDS = set(["один", "одна", "одно", "одного", "одним", "два", "две", "двух", "двумя", "три", "трех", "тремя", "четыре", "четырех", "пять", "пяти", "шесть", "шести", "семь", "семи", "восемь", "восьми", "девять", "девяти", "десять", "десяти", "одиннадцать", "двенадцать", "двадцать", "тридцать", "сорок", "пятьдесят", "сто", "ста", "тысяча", "тысячи", "тысяч", "миллион", "миллиона", "миллиард", "первый", "первая", "второй", "вторая", "третий", "третья", "четвертый", "пятый", "вдвое", "втрое", "вчетверо", "половина", "треть", "четверть"])
 
 # Заглавные нарицательные, которые не являются проверяемым фактом.
-NOT_A_FACT = set("""
-Вселенной Вселенная Земля Земли Интернет Интернете
-""".split())
+NOT_A_FACT = set(["Вселенной", "Вселенная", "Земля", "Земли", "Интернет", "Интернете"])
 
 WORD_RX = re.compile(r"[а-яё]+")
 NUM_RX = re.compile(r"\d+")
@@ -193,8 +183,8 @@ def selftest():
     # Обратная сторона: единичный файл без пар — законный случай, порог молчит.
     tmp = tempfile.mkdtemp()
     lone = os.path.join(tmp, "без-пар.md")
-    with io.open(lone, "w", encoding="utf-8") as fh:
-        fh.write(u"# Файл без примеров\n\nПросто текст.\n")
+    with pathlib.Path(lone).open("w", encoding="utf-8") as fh:
+        fh.write("# Файл без примеров\n\nПросто текст.\n")
     saved_argv = sys.argv
     try:
         sys.argv = ["check_examples.py", lone]
@@ -221,13 +211,13 @@ def main():
     files = args.files
     full_run = not files
     if not files:
-        files = [os.path.join(ROOT, f) for f in TARGETS if os.path.exists(os.path.join(ROOT, f))]
+        files = [os.path.join(ROOT, f) for f in TARGETS if pathlib.Path(os.path.join(ROOT, f)).exists()]
         files += sorted(glob.glob(os.path.join(ROOT, "references", "*.md")))
 
     all_err, all_warn = [], []
     total = {"pairs": 0, "edit": 0, "authored": 0}
     for path in files:
-        with open(path, encoding="utf-8") as fh:
+        with pathlib.Path(path).open(encoding="utf-8") as fh:
             text = fh.read()
         rel = os.path.relpath(path, ROOT)
         errs, warns, stats = check_text(text, rel)

--- a/scripts/check_fixture_sources.py
+++ b/scripts/check_fixture_sources.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Проверка реестра источников для образцов маркеров (issue #18). Версия 3.
 
 Отличие от версии 1: статуса confirmed недостаточно, чтобы закрыть гейт.
@@ -24,9 +23,9 @@
 Только стандартная библиотека. Коды возврата: 0 - гейт пройден, 1 - нарушения, 2 - ошибка входа.
 """
 
-import io
 import json
 import os
+import pathlib
 import re
 import sys
 
@@ -39,11 +38,11 @@ if hasattr(sys.stdout, "reconfigure"):
 # новые маркеры, не добавленные в реестр (новый case обязан попасть в SCOPE).
 try:
     from check_markers import CASES as _MARKER_CASES
-except Exception:  # noqa: BLE001 — fallback, если запуск из другого каталога
+except Exception:  # ruff:ignore[blind-except] — fallback, если запуск из другого каталога
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     try:
         from check_markers import CASES as _MARKER_CASES
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:  # ruff:ignore[blind-except]
         print("Не удалось импортировать CASES из check_markers.py: %s" % exc, file=sys.stderr)
         _MARKER_CASES = {}
 
@@ -108,7 +107,7 @@ def _reject_path(fixture, base_dir, repo_root=None):
     if fixture != fixture.strip():
         return "fixture_file не должен начинаться или заканчиваться пробелом"
     native = fixture.replace("\\", "/")
-    if os.path.isabs(fixture) or os.path.isabs(native) or re.match(r"^[A-Za-z]:", fixture):
+    if pathlib.Path(fixture).is_absolute() or pathlib.Path(native).is_absolute() or re.match(r"^[A-Za-z]:", fixture):
         return "fixture_file должен быть относительным путём, получено: " + fixture
     root = os.path.abspath(repo_root or REPO_ROOT)
     target = os.path.abspath(os.path.join(base_dir, fixture))
@@ -187,10 +186,10 @@ def validate(entries, base_dir=".", allow_pending=False, repo_root=None):
                 fixture = None
         if fixture:
             path = os.path.join(base_dir, fixture)
-            if not os.path.isfile(path):
+            if not pathlib.Path(path).is_file():
                 errors.append(tag + ": fixture_file не найден: " + str(fixture))
             else:
-                with open(path, encoding="utf-8") as fh:
+                with pathlib.Path(path).open(encoding="utf-8") as fh:
                     raw = fh.read()
                 if not re.search(SCOPE[case], raw):
                     errors.append(tag + ": fixture_file не содержит маркер " + case)
@@ -239,7 +238,7 @@ def validate(entries, base_dir=".", allow_pending=False, repo_root=None):
 
 def run(path, allow_pending):
     try:
-        with open(path, encoding="utf-8") as fh:
+        with pathlib.Path(path).open(encoding="utf-8") as fh:
             entries = json.load(fh)
     except (OSError, json.JSONDecodeError) as exc:
         print("Не удалось прочитать %s: %s" % (path, exc), file=sys.stderr)
@@ -387,10 +386,10 @@ def selftest():
 
     # Легитимная форма из живого реестра: относительный путь внутрь tests/.
     nested = os.path.join(base, "tests", "fixtures")
-    os.makedirs(nested, exist_ok=True)
+    pathlib.Path(nested).mkdir(exist_ok=True, parents=True)
     legit_rel = os.path.join("tests", "fixtures", "pua-образец.txt")
-    with io.open(os.path.join(base, legit_rel), "w", encoding="utf-8") as fh:
-        fh.write(u"известная по ролям.2\n")
+    with pathlib.Path(os.path.join(base, legit_rel)).open("w", encoding="utf-8") as fh:
+        fh.write("известная по ролям.2\n")
     good = json.loads(json.dumps(ok))
     for e in good:
         if e["case"] == "openai_pua_short":
@@ -399,7 +398,7 @@ def selftest():
     checks.append(("относительный путь внутрь репозитория остаётся допустимым",
                    not err and len(cov) == 14))
 
-    os.unlink(tmp.name); os.unlink(synth.name)
+    pathlib.Path(tmp.name).unlink(); pathlib.Path(synth.name).unlink()
     fails = [n for n, p in checks if not p]
     for n, p in checks:
         print(("PASS: " if p else "FAIL: ") + n)

--- a/scripts/check_markers.py
+++ b/scripts/check_markers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Прогон регулярных выражений из references/chatbot-artifacts.md
 по проверочным образцам из references/test-fixtures.md.
 
@@ -16,6 +15,7 @@
 Ни одно работающее правило не удаляется (см. принцип в test-fixtures.md).
 """
 
+import pathlib
 import re
 import sys
 
@@ -402,7 +402,7 @@ def scan(paths: list) -> int:
     found = 0
     for path in paths:
         try:
-            with open(path, encoding="utf-8") as fh:
+            with pathlib.Path(path).open(encoding="utf-8") as fh:
                 lines = fh.read().splitlines()
         except OSError as exc:
             print(f"Не удалось прочитать {path}: {exc}", file=sys.stderr)
@@ -471,7 +471,7 @@ def parity(md_path: str = "references/chatbot-artifacts.md") -> int:
     задокументированы, 1 — есть недокументированные (regex без описания).
     """
     try:
-        with open(md_path, encoding="utf-8") as fh:
+        with pathlib.Path(md_path).open(encoding="utf-8") as fh:
             doc = _canon_pattern(fh.read())
     except OSError as exc:
         print(f"Не удалось прочитать {md_path}: {exc}", file=sys.stderr)

--- a/scripts/check_perf.py
+++ b/scripts/check_perf.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""check_perf.py — перф-гейт выражений маркеров (docs/REVIEW.md, класс B).
+r"""check_perf.py — перф-гейт выражений маркеров (docs/REVIEW.md, класс B).
 
 Требование REVIEW.md: выражение не дольше 0.5 с на входе в 30 000 символов.
 До этого гейта требование существовало только на словах: ни один валидатор
@@ -41,7 +40,7 @@ if hasattr(sys.stdout, "reconfigure"):
 
 try:
     from check_markers import CASES
-except Exception:  # noqa: BLE001 — запуск не из каталога scripts/
+except Exception:  # ruff:ignore[blind-except] — запуск не из каталога scripts/
     sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
     from check_markers import CASES
 
@@ -58,26 +57,26 @@ def _grow(chunk, size=CORPUS_SIZE):
 def make_corpora(size=CORPUS_SIZE):
     """Четыре синтетических корпуса по size символов."""
     prose = _grow(
-        u"Утром пошёл дождь, и мы решили остаться дома. "
-        u"Кофе закончился, пришлось идти в магазин на углу. "
-        u"Продавщица сказала, что привоз будет только к вечеру. ", size)
+        "Утром пошёл дождь, и мы решили остаться дома. "
+        "Кофе закончился, пришлось идти в магазин на углу. "
+        "Продавщица сказала, что привоз будет только к вечеру. ", size)
     near_miss = _grow(
-        u"turn0searchX citeturn0 oaicite: contentReferenc "
-        u"attached_file grok_render_citation_car <thin> "
-        u"utm_source=copilot utm_medium=chat 2025-13-XX Excel+1С ", size)
+        "turn0searchX citeturn0 oaicite: contentReferenc "
+        "attached_file grok_render_citation_car <thin> "
+        "utm_source=copilot utm_medium=chat 2025-13-XX Excel+1С ", size)
     # Домены зарезервированы RFC 2606: корпус нужен для плотности ссылок и
     # параметров запроса, а не для воспроизведения примет конкретных моделей.
     urls = _grow(
-        u"https://example.org/page?utm_source=news&utm_medium=mail&id=42 "
-        u"https://example.net/files/report.pdf?ref=1&token=abcdef "
-        u"https://example.com/search?q=test&page=7&sort=date ", size)
-    long_line = _grow(u"аaбbвcгdдeеfжgзhиiйjкkлlмmнnоoпpрqсrтsуtфuхvцwчxшyщzъ", size)
+        "https://example.org/page?utm_source=news&utm_medium=mail&id=42 "
+        "https://example.net/files/report.pdf?ref=1&token=abcdef "
+        "https://example.com/search?q=test&page=7&sort=date ", size)
+    long_line = _grow("аaбbвcгdдeеfжgзhиiйjкkлlмmнnоoпpрqсrтsуtфuхvцwчxшyщzъ", size)
     # Ловушка откатов. Намеренно короткая: у выражения с вложенной
     # квантификацией время растёт экспоненциально от числа токенов, поэтому
     # опасное поведение видно уже на 22 токенах, а на 30 000 символов прогон
     # не завершился бы вовсе. Хвост «!» не даёт выражению совпасть до конца
     # строки — именно это запускает полный перебор разбиений.
-    backtrack = (u"сл " * 22) + u"!"
+    backtrack = ("сл " * 22) + "!"
     return [
         ("проза", prose),
         ("near-miss", near_miss),

--- a/scripts/check_readme_parity.py
+++ b/scripts/check_readme_parity.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Проверяет паритет и правдивость русской и английской витрины.
 
 Числа покрытия сверяются не только между README, но и с исполняемыми
 источниками истины: REGISTERED_CASES и CASES. Разделы должны быть настоящими
 заголовками H2/H3, а не случайными словами в тексте.
 """
-import io
 import os
+import pathlib
 import re
 import sys
 
@@ -23,39 +22,39 @@ SHOWCASE = (RU, EN, SKILL)
 OK, FAIL = "[OK]", "[FAIL]"
 
 # Кодпоинты не дают self-scan принять тестовые данные за живые маркеры.
-CIRCLES = (u"\U0001F534", u"\U0001F7E1", u"\U0001F7E2")
-CIRCLE_NAMES = dict(zip(CIRCLES, (u"красный", u"жёлтый", u"зелёный")))
+CIRCLES = ("\U0001F534", "\U0001F7E1", "\U0001F7E2")
+CIRCLE_NAMES = dict(zip(CIRCLES, ("красный", "жёлтый", "зелёный")))
 
 SECTIONS = [
-    (u"Что ему давать", u"What to give it"),
-    (u"Установка за 30 секунд", u"Install in 30 seconds"),
-    (u"Установка вручную", u"Manual install"),
-    (u"Использование", u"Usage"),
-    (u"Что делает", u"What it does"),
-    (u"Regex-маркеры", u"Regex markers"),
-    (u"Архитектура", u"Architecture"),
-    (u"Безопасность", u"Security"),
-    (u"Источники", u"Sources"),
-    (u"История изменений", u"Changelog"),
-    (u"Лицензия", u"License"),
+    ("Что ему давать", "What to give it"),
+    ("Установка за 30 секунд", "Install in 30 seconds"),
+    ("Установка вручную", "Manual install"),
+    ("Использование", "Usage"),
+    ("Что делает", "What it does"),
+    ("Regex-маркеры", "Regex markers"),
+    ("Архитектура", "Architecture"),
+    ("Безопасность", "Security"),
+    ("Источники", "Sources"),
+    ("История изменений", "Changelog"),
+    ("Лицензия", "License"),
 ]
 RU_ONLY = [
-    u"Содержательные паттерны", u"Языковые паттерны",
-    u"Структурные и стилевые паттерны", u"Коммуникативные паттерны",
-    u"Подлог источников", u"Границы ложного срабатывания",
-    u"Отпечатки моделей", u"Отличия от английской версии",
+    "Содержательные паттерны", "Языковые паттерны",
+    "Структурные и стилевые паттерны", "Коммуникативные паттерны",
+    "Подлог источников", "Границы ложного срабатывания",
+    "Отпечатки моделей", "Отличия от английской версии",
 ]
 
-PATTERNS_RX = re.compile(u"(\\d+)\\s+(?:паттернов|patterns)", re.I)
+PATTERNS_RX = re.compile("(\\d+)\\s+(?:паттернов|patterns)", re.I)
 MARKERS_RX = re.compile(
-    u"(\\d+)\\s+(?:[^\\W\\d_]+\\s+){0,2}(?:regex|регулярных)"
-    u"[-\\s]?(?:маркеров|markers|выражений)", re.I | re.U)
-COVERAGE_RX = re.compile(u"(\\d+)\\s+(?:из|of)\\s+(\\d+)", re.I)
-HEADING_RX = re.compile(u"^#{2,3}\\s+(.+?)\\s*$", re.M)
+    "(\\d+)\\s+(?:[^\\W\\d_]+\\s+){0,2}(?:regex|регулярных)"
+    "[-\\s]?(?:маркеров|markers|выражений)", re.I | re.U)
+COVERAGE_RX = re.compile("(\\d+)\\s+(?:из|of)\\s+(\\d+)", re.I)
+HEADING_RX = re.compile("^#{2,3}\\s+(.+?)\\s*$", re.M)
 
 
 def read(path):
-    with io.open(path, encoding="utf-8") as fh:
+    with pathlib.Path(path).open(encoding="utf-8") as fh:
         return fh.read()
 
 
@@ -81,7 +80,7 @@ def source_truth():
 
 
 def headings(text):
-    return [re.sub(u"\\s+#+$", u"", item).strip()
+    return [re.sub("\\s+#+$", "", item).strip()
             for item in HEADING_RX.findall(text)]
 
 
@@ -92,27 +91,27 @@ def has_heading(items, fragment):
 def check_numbers(ru_text, en_text, expected=None):
     errors = []
     ru, en = claims(ru_text), claims(en_text)
-    titles = (("patterns", u"количество паттернов"),
-              ("markers", u"количество regex-маркеров"),
-              ("coverage", u"покрытие реестра доказательств"))
+    titles = (("patterns", "количество паттернов"),
+              ("markers", "количество regex-маркеров"),
+              ("coverage", "покрытие реестра доказательств"))
     for key, title in titles:
         if ru[key] is None:
-            errors.append(u"%s: не заявлено %s" % (RU, title))
+            errors.append("%s: не заявлено %s" % (RU, title))
         if en[key] is None:
-            errors.append(u"%s: не заявлено %s" % (EN, title))
+            errors.append("%s: не заявлено %s" % (EN, title))
         if ru[key] and en[key] and set(ru[key]) != set(en[key]):
-            errors.append(u"%s расходится: %s %s, %s %s"
+            errors.append("%s расходится: %s %s, %s %s"
                           % (title, RU, ru[key], EN, en[key]))
     if expected:
         wanted = {tuple(expected)}
         for name, data in ((RU, ru), (EN, en)):
             actual = set(data["coverage"] or [])
             if actual != wanted:
-                errors.append(u"%s: покрытие %s, по коду должно быть %s"
+                errors.append("%s: покрытие %s, по коду должно быть %s"
                               % (name, sorted(actual), sorted(wanted)))
             markers = set(data["markers"] or [])
             if expected[1] not in markers:
-                errors.append(u"%s: число regex-маркеров %s, в CASES их %d"
+                errors.append("%s: число regex-маркеров %s, в CASES их %d"
                               % (name, sorted(markers), expected[1]))
     return errors
 
@@ -122,12 +121,12 @@ def check_sections(ru_text, en_text):
     ru_heads, en_heads = headings(ru_text), headings(en_text)
     for ru_name, en_name in SECTIONS:
         if not has_heading(ru_heads, ru_name):
-            errors.append(u"%s: нет заголовка H2/H3 «%s»" % (RU, ru_name))
+            errors.append("%s: нет заголовка H2/H3 «%s»" % (RU, ru_name))
         if not has_heading(en_heads, en_name):
-            errors.append(u"%s: нет заголовка H2/H3 «%s»" % (EN, en_name))
+            errors.append("%s: нет заголовка H2/H3 «%s»" % (EN, en_name))
     for name in RU_ONLY:
         if not has_heading(ru_heads, name):
-            errors.append(u"%s: нет русского раздела H2/H3 «%s»" % (RU, name))
+            errors.append("%s: нет русского раздела H2/H3 «%s»" % (RU, name))
     return errors
 
 
@@ -136,7 +135,7 @@ def check_circles(name, text):
     for line_no, line in enumerate(text.split("\n"), 1):
         for circle in CIRCLES:
             if circle in line:
-                errors.append(u"%s:%d кружок критичности (%s) — нужно слово"
+                errors.append("%s:%d кружок критичности (%s) — нужно слово"
                               % (name, line_no, CIRCLE_NAMES[circle]))
                 break
     return errors
@@ -150,8 +149,8 @@ def check_all(texts, expected=None):
     return errors
 
 
-RU_ONLY_SAMPLE = u"\n".join(u"### " + name for name in RU_ONLY)
-GOOD_RU = u"""# Скилл
+RU_ONLY_SAMPLE = "\n".join("### " + name for name in RU_ONLY)
+GOOD_RU = """# Скилл
 37 паттернов и 38 regex-маркеров.
 Запись доказательств есть у 14 из 38 маркеров.
 ## Что ему давать
@@ -165,8 +164,8 @@ GOOD_RU = u"""# Скилл
 ## Источники
 ## История изменений
 ## Лицензия
-""" + RU_ONLY_SAMPLE + u"\n"
-GOOD_EN = u"""# Skill
+""" + RU_ONLY_SAMPLE + "\n"
+GOOD_EN = """# Skill
 37 patterns and 38 regex markers.
 Currently 14 of 38 markers have a full record.
 ## What to give it
@@ -181,7 +180,7 @@ Currently 14 of 38 markers have a full record.
 ## Changelog
 ## License
 """
-GOOD_SKILL = u"# Карта\nКритичность: высокая, средняя, низкая.\n"
+GOOD_SKILL = "# Карта\nКритичность: высокая, средняя, низкая.\n"
 EXPECTED = (14, 38)
 
 
@@ -190,8 +189,8 @@ def _has(errors, fragment):
 
 
 def _case(name, condition, detail=""):
-    print(u"%s %s%s" % (OK if condition else FAIL, name,
-          (u" — " + detail) if detail and not condition else ""))
+    print("%s %s%s" % (OK if condition else FAIL, name,
+          (" — " + detail) if detail and not condition else ""))
     return bool(condition)
 
 
@@ -200,45 +199,45 @@ def selftest():
     base = {RU: GOOD_RU, EN: GOOD_EN, SKILL: GOOD_SKILL}
     results = []
     errors = check_all(base, EXPECTED)
-    results.append(_case(u"Согласованная витрина проходит", not errors,
-                         u"; ".join(errors)))
+    results.append(_case("Согласованная витрина проходит", not errors,
+                         "; ".join(errors)))
     wordy = dict(base)
-    wordy[EN] = GOOD_EN.replace(u"38 regex markers", u"38 testable regex markers")
-    results.append(_case(u"Определение перед regex не мешает",
+    wordy[EN] = GOOD_EN.replace("38 regex markers", "38 testable regex markers")
+    results.append(_case("Определение перед regex не мешает",
                          not check_all(wordy, EXPECTED)))
-    bad = dict(base); bad[EN] = GOOD_EN.replace(u"37 patterns", u"54 patterns")
-    results.append(_case(u"Разное число паттернов отклоняется",
-                         _has(check_all(bad, EXPECTED), u"количество паттернов")))
-    bad = dict(base); bad[EN] = GOOD_EN.replace(u"38 regex markers", u"41 regex markers")
-    results.append(_case(u"Разное число маркеров отклоняется",
-                         _has(check_all(bad, EXPECTED), u"regex-маркеров")))
+    bad = dict(base); bad[EN] = GOOD_EN.replace("37 patterns", "54 patterns")
+    results.append(_case("Разное число паттернов отклоняется",
+                         _has(check_all(bad, EXPECTED), "количество паттернов")))
+    bad = dict(base); bad[EN] = GOOD_EN.replace("38 regex markers", "41 regex markers")
+    results.append(_case("Разное число маркеров отклоняется",
+                         _has(check_all(bad, EXPECTED), "regex-маркеров")))
     bad = dict(base)
-    bad[RU] = GOOD_RU.replace(u"14 из 38", u"38 из 38")
-    bad[EN] = GOOD_EN.replace(u"14 of 38", u"38 of 38")
-    results.append(_case(u"Синхронное завышение покрытия отклоняется",
-                         _has(check_all(bad, EXPECTED), u"по коду должно быть")))
+    bad[RU] = GOOD_RU.replace("14 из 38", "38 из 38")
+    bad[EN] = GOOD_EN.replace("14 of 38", "38 of 38")
+    results.append(_case("Синхронное завышение покрытия отклоняется",
+                         _has(check_all(bad, EXPECTED), "по коду должно быть")))
     bad = dict(base); bad[RU] = GOOD_RU.replace(
-        u"Запись доказательств есть у 14 из 38 маркеров.\n", u"")
-    results.append(_case(u"Умолчание о покрытии отклоняется",
-                         _has(check_all(bad, EXPECTED), u"не заявлено покрытие")))
-    bad = dict(base); bad[EN] = GOOD_EN.replace(u"## Security", u"Security")
-    results.append(_case(u"Обычный текст вместо заголовка отклоняется",
-                         _has(check_all(bad, EXPECTED), u"Security")))
-    bad = dict(base); bad[EN] = GOOD_EN.replace(u"## Security", u"###### Security")
-    results.append(_case(u"H6 вместо H2/H3 отклоняется",
-                         _has(check_all(bad, EXPECTED), u"Security")))
+        "Запись доказательств есть у 14 из 38 маркеров.\n", "")
+    results.append(_case("Умолчание о покрытии отклоняется",
+                         _has(check_all(bad, EXPECTED), "не заявлено покрытие")))
+    bad = dict(base); bad[EN] = GOOD_EN.replace("## Security", "Security")
+    results.append(_case("Обычный текст вместо заголовка отклоняется",
+                         _has(check_all(bad, EXPECTED), "Security")))
+    bad = dict(base); bad[EN] = GOOD_EN.replace("## Security", "###### Security")
+    results.append(_case("H6 вместо H2/H3 отклоняется",
+                         _has(check_all(bad, EXPECTED), "Security")))
     bad = dict(base); bad[RU] = GOOD_RU.replace(
-        u"### Содержательные паттерны", u"### Другое")
-    results.append(_case(u"Пропавший русский раздел отклоняется",
-                         _has(check_all(bad, EXPECTED), u"Содержательные паттерны")))
-    bad = dict(base); bad[RU] = GOOD_RU + CIRCLES[0] + u"\n"
-    results.append(_case(u"Кружок в README отклоняется",
-                         _has(check_all(bad, EXPECTED), u"кружок критичности")))
-    bad = dict(base); bad[SKILL] = GOOD_SKILL + CIRCLES[2] + u"\n"
-    results.append(_case(u"Кружок в карте скилла отклоняется",
-                         _has(check_all(bad, EXPECTED), u"кружок критичности")))
+        "### Содержательные паттерны", "### Другое")
+    results.append(_case("Пропавший русский раздел отклоняется",
+                         _has(check_all(bad, EXPECTED), "Содержательные паттерны")))
+    bad = dict(base); bad[RU] = GOOD_RU + CIRCLES[0] + "\n"
+    results.append(_case("Кружок в README отклоняется",
+                         _has(check_all(bad, EXPECTED), "кружок критичности")))
+    bad = dict(base); bad[SKILL] = GOOD_SKILL + CIRCLES[2] + "\n"
+    results.append(_case("Кружок в карте скилла отклоняется",
+                         _has(check_all(bad, EXPECTED), "кружок критичности")))
     passed = sum(results)
-    print(u"Итог: %d/%d" % (passed, len(results)))
+    print("Итог: %d/%d" % (passed, len(results)))
     return 0 if passed == len(results) else 1
 
 
@@ -249,11 +248,11 @@ def main():
     expected = source_truth()
     errors = check_all(texts, expected)
     for error in errors:
-        print(u"%s %s" % (FAIL, error))
+        print("%s %s" % (FAIL, error))
     if errors:
-        print(u"Ошибок: %d." % len(errors))
+        print("Ошибок: %d." % len(errors))
         return 1
-    print(u"%s Витрина согласована; покрытие по коду: %d из %d."
+    print("%s Витрина согласована; покрытие по коду: %d из %d."
           % (OK, expected[0], expected[1]))
     return 0
 

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -8,15 +8,13 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import io
-import os
-from pathlib import Path, PurePosixPath
 import re
 import stat
 import sys
 import tempfile
 import warnings
 import zipfile
+from pathlib import Path, PurePosixPath
 
 # Консоли Windows (cp866/cp1251/ascii) не должны ронять валидатор на кириллице.
 if hasattr(sys.stdout, "reconfigure"):
@@ -44,8 +42,10 @@ EXCLUDED_SCRIPTS = {"scripts/check_corpus.py"}
 SECRET_NAME_RE = re.compile(r"(?:^|[._-])(secret|token|credential|private[_-]?key)(?:$|[._-])", re.I)
 FIXED_TIME = (2026, 7, 21, 0, 0, 0)
 
+
 class ReleaseError(ValueError):
     pass
+
 
 def sha256(path: Path) -> str:
     h = hashlib.sha256()
@@ -53,6 +53,7 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: f.read(1024 * 1024), b""):
             h.update(chunk)
     return h.hexdigest()
+
 
 def _safe_rel(path: str) -> PurePosixPath:
     if "\\" in path:
@@ -62,10 +63,12 @@ def _safe_rel(path: str) -> PurePosixPath:
         raise ReleaseError(f"unsafe archive path: {path!r}")
     return p
 
+
 def _allowed(p: PurePosixPath) -> bool:
     if len(p.parts) == 1:
         return p.name in ROOT_FILES
     return p.parts[0] in ROOT_DIRS
+
 
 def _validate_name(p: PurePosixPath) -> None:
     if any(part in FORBIDDEN_PARTS for part in p.parts):
@@ -77,11 +80,13 @@ def _validate_name(p: PurePosixPath) -> None:
     if not _allowed(p):
         raise ReleaseError(f"path is outside release allowlist: {p}")
 
+
 def _validate_text(name: str, data: bytes) -> None:
     try:
         data.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise ReleaseError(f"text file is not UTF-8: {name}: {exc}") from exc
+
 
 def collect(root: Path) -> list[tuple[PurePosixPath, bytes]]:
     root = root.resolve()
@@ -117,6 +122,7 @@ def collect(root: Path) -> list[tuple[PurePosixPath, bytes]]:
         raise ReleaseError("references/ must contain at least one file")
     return found
 
+
 def build(root: Path, output: Path) -> str:
     files = collect(root)
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -129,9 +135,10 @@ def build(root: Path, output: Path) -> str:
             info.external_attr = (stat.S_IFREG | 0o644) << 16
             info.flag_bits |= 0x800
             zf.writestr(info, data, compress_type=zipfile.ZIP_DEFLATED, compresslevel=9)
-    os.replace(tmp, output)
+    Path(tmp).replace(output)
     verify(output)
     return sha256(output)
+
 
 def verify(archive: Path) -> str:
     if not archive.is_file():
@@ -161,6 +168,7 @@ def verify(archive: Path) -> str:
             raise ReleaseError("references/ missing from ZIP")
     return sha256(archive)
 
+
 def _minimal(root: Path) -> None:
     (root / "references").mkdir(parents=True)
     (root / "scripts").mkdir(parents=True)
@@ -168,9 +176,11 @@ def _minimal(root: Path) -> None:
     (root / "references" / "test.md").write_text("Тест \uea01 1 \uea02\n", encoding="utf-8")
     (root / "scripts" / "noop.py").write_text("print('ok')\n", encoding="utf-8")
 
+
 def selftest() -> None:
     passed = 0
     total = 0
+
     def expect_fail(fn, label: str) -> None:
         nonlocal passed, total
         total += 1
@@ -258,6 +268,7 @@ def selftest() -> None:
         expect_fail(lambda: verify(sneaked), "excluded script inside archive")
     print(f"release preflight selftest: {passed}/{total} PASS")
 
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--selftest", action="store_true")
@@ -286,6 +297,7 @@ def main(argv: list[str] | None = None) -> int:
     except (ReleaseError, OSError, zipfile.BadZipFile, AssertionError) as exc:
         print(f"release preflight: FAIL: {exc}", file=sys.stderr)
         return 1
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/check_spec.py
+++ b/scripts/check_spec.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """check_spec.py — проверка SKILL.md на соответствие Agent Skills Specification.
 
 Источник требований: https://agentskills.io/specification (снимок от 2026-07-13).
@@ -15,9 +14,9 @@
 Коды выхода: 0 — соответствует; 1 — есть нарушения; 2 — ошибка запуска или чтения.
 """
 import os
+import pathlib
 import re
 import sys
-import tempfile
 
 # Консоли Windows (cp866/cp1251/ascii) не должны ронять валидатор на кириллице.
 if hasattr(sys.stdout, "reconfigure"):
@@ -248,7 +247,7 @@ def run_checks(text, skill_dir_name, strict=False):
 
 
 def run_file(path, strict=False, expect_dir=None):
-    with open(path, "r", encoding="utf-8") as f:
+    with pathlib.Path(path).open(encoding="utf-8") as f:
         text = f.read()
     dir_name = expect_dir or os.path.basename(os.path.dirname(os.path.abspath(path)))
     return run_checks(text, dir_name, strict=strict)
@@ -331,7 +330,7 @@ def main(argv):
             return 2
         del args[k:k + 2]
     path = args[0] if args else "SKILL.md"
-    if not os.path.isfile(path):
+    if not pathlib.Path(path).is_file():
         print("файл не найден: %s" % path)
         return 2
     return _report(run_file(path, strict=strict, expect_dir=expect_dir))

--- a/scripts/count_style_markers.py
+++ b/scripts/count_style_markers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Объективный подсчёт стилевых нарушений для A/B-теста PERSONA.md (issue #19).
 
 Один ответ модели = один текстовый файл. Считает:
@@ -14,7 +13,7 @@
     python3 scripts/count_style_markers.py --selftest
 Вывод: TSV-строка на файл + итог. Коды: 0 - ok, 1 - провал самопроверки, 2 - ошибка входа.
 """
-import io
+import pathlib
 import re
 import sys
 
@@ -85,7 +84,7 @@ def main(paths, skip_markup=False):
     grand = 0
     for p in paths:
         try:
-            with io.open(p, encoding="utf-8") as fh:
+            with pathlib.Path(p).open(encoding="utf-8") as fh:
                 raw = fh.read()
         except OSError as exc:
             print("ошибка чтения %s: %s" % (p, exc), file=sys.stderr)
@@ -118,13 +117,13 @@ def selftest():
 
     # --skip-markup: структура документа не должна попадать в стилевой счёт,
     # а проза внутри разметки — должна.
-    md = (u"# Заголовок\n\n"
-          u"- первый пункт\n- второй пункт\n\n"
-          u"| столбец | значение |\n|---|---|\n| a | b |\n\n"
-          u"```python\n# важно отметить в коде\nx = 1\n```\n\n"
-          u"См. [документацию](https://example.org/важно-отметить).\n\n"
-          u"**Важно отметить**, что текст остаётся прозой.\n"
-          u"Встрочный `код` и обычная фраза.\n")
+    md = ("# Заголовок\n\n"
+          "- первый пункт\n- второй пункт\n\n"
+          "| столбец | значение |\n|---|---|\n| a | b |\n\n"
+          "```python\n# важно отметить в коде\nx = 1\n```\n\n"
+          "См. [документацию](https://example.org/важно-отметить).\n\n"
+          "**Важно отметить**, что текст остаётся прозой.\n"
+          "Встрочный `код` и обычная фраза.\n")
     raw_counts = count_text(md)
     skipped = count_text(strip_markup(md))
     checks += [
@@ -135,10 +134,10 @@ def selftest():
         ("skip: слово-подушка из блока кода не считается",
          skipped["pillow"] < raw_counts["pillow"]),
         ("skip: строки таблицы не считаются",
-         u"столбец" not in strip_markup(md)),
+         "столбец" not in strip_markup(md)),
         ("skip: адрес ссылки убран, видимый текст остался",
-         u"example.org" not in strip_markup(md)
-         and u"документацию" in strip_markup(md)),
+         "example.org" not in strip_markup(md)
+         and "документацию" in strip_markup(md)),
         ("skip: обычный текст не портится",
          count_text(strip_markup(good)) == cg),
     ]


### PR DESCRIPTION
Readability and style fixes in the humanizer-ru text processing scripts from ShipGate auto-fix on core source dirs.

## Summary

*Review run with ShipGate 0.1.7.*

ShipGate reported **~1265 format/style findings**, **~2126 lint findings** in the full check suite. Security, duplication, and maintainability dimensions are summarized below; see the linked gist for raw captures.

Hotspots and improvement notes below are scoped to **Python (`*.py`)** source.
### File hotspots

| File | Issues | Action |
| --- | ---: | --- |
| `scripts/check_docs.py` | ~372 lint | address E111; address RUF001 |
| `eval/blind_eval.py` | ~191 lint | prefer f-strings over % formatting (UP031); address RUF001 |
| `scripts/check_readme_parity.py` | ~162 lint | address UP025; prefer f-strings over % formatting (UP031) |
| `scripts/count_style_markers.py` | ~159 lint | address RUF001; address UP025 |
| `eval/run_eval.py` | ~149 lint | address RUF001; prefer pathlib Path over os.path.join (PTH118) |
| `scripts/check_spec.py` | ~113 lint | address RUF001; prefer f-strings over % formatting (UP031) |
| `scripts/check_fixture_sources.py` | ~108 lint | address RUF001; prefer f-strings over % formatting (UP031) |
| `scripts/check_markers.py` | ~107 lint | address RUF001; wrap long lines or align with project line-length (E501) |
| `scripts/check_corpus.py` | ~82 lint | prefer pathlib Path over os.path.join (PTH118); address RUF001 |
### Refactor hints (optional apply)

*No hint-tier refactor opportunities in scope (or `refactor-strict.out` empty).*
## What you are doing right

- **Security:** No high-severity bandit hits or secrets flagged by gitleaks/semgrep in the scanned scope.
- **Dead code:** vulture/deadcode found few or no unused symbols in production modules.
- **Refactoring:** Strict refactor scan found only ~0 opportunities — structure is relatively stable.

## What you could improve

- **Duplication (~7.5%):** jscpd reports duplicate blocks above the configured threshold — review clustered paths in hotspots.
- **Complexity:** radon flagged functions or modules above cyclomatic-complexity gates — consider incremental extraction.
- **Lint / style (~2126 findings):** Many items are formatting or style rules — align fixes with your existing ruff/pyproject config.
- **Hotspot:** `scripts/check_docs.py` concentrates the most findings — start there for incremental cleanup.

## Changes

| Pass | Files | Fixes / rules | Manual? |
| --- | ---: | --- | --- |
| `shipgate format` | 0 | timeout or non-zero exit | no |
| **Total** | **0** | *See autofix.log for details* | — |
