### PR TITLE
README и CI: команда установки бандла + гейт установки в dsh

### DIFF
--- a/.github/workflows/dsh-install.yml
+++ b/.github/workflows/dsh-install.yml
@@ -1,0 +1,114 @@
+name: Установка бандла в dsh
+
+# Бандл dsh/ ставит штатный менеджер плагинов, а не тесты проекта, поэтому
+# остальные 36 гейтов его установку не проверяют. Здесь закрыты два разных
+# отказа: правка в репозитории ломает бандл, либо новая версия dsh ломает
+# совместимость с ним. dsh - developer preview, ломающие изменения обещаны.
+#
+# Код возврата 0 сам по себе ничего не доказывает. Замер 2026-08-16: форма
+# `#v3.13.0&path:/dsh` дала exit 0, но pnpm молча отбросил `&path:/dsh`,
+# поставил репозиторий целиком обычной зависимостью, и профиль остался без
+# слоя. Поэтому гейт сверяет строку в dsh.profile.bundles и файлы на диске.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dsh/**'
+      - 'SKILL.md'
+      - 'references/**'
+      - '.github/workflows/dsh-install.yml'
+  pull_request:
+    paths:
+      - 'dsh/**'
+      - 'SKILL.md'
+      - 'references/**'
+      - '.github/workflows/dsh-install.yml'
+  schedule:
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dsh-install-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUNDLE: humanizer-ru-dsh
+  SKILL_PATH: skills/humanizer-ru/SKILL.md
+  DSH_PINNED: 0.1.0-rc.6
+
+jobs:
+  worktree:
+    name: Бандл из рабочего дерева ставится и снимается
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: pnpm на PATH и закреплённая версия dsh
+        run: |
+          set -euo pipefail
+          npm install -g pnpm@10
+          npm install -g "@deepseek-ai/dsh@${DSH_PINNED}"
+          echo "dsh $(dsh --version), pnpm $(pnpm --version)"
+
+      - name: Установка в чистый профиль
+        run: dsh plugin --profile smoke add "${GITHUB_WORKSPACE}/dsh"
+
+      - name: Бандл стал слоем профиля, файлы на месте
+        run: |
+          set -euo pipefail
+          profile="${HOME}/.dsh/profiles/smoke"
+          python3 -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); b=d['dsh']['profile']['bundles']; print('bundles:', b); sys.exit(0 if sys.argv[2] in b else 1)" "${profile}/package.json" "${BUNDLE}"
+          test -f "${profile}/node_modules/${BUNDLE}/cordis.patch.yml"
+          test -f "${profile}/node_modules/${BUNDLE}/${SKILL_PATH}"
+          echo "Слой на месте, вендорная копия скилла тоже."
+
+      - name: Вендорная копия совпадает с источником
+        run: python3 scripts/check_bundle_sync.py
+
+      - name: Снятие возвращает профиль в исходное состояние
+        run: |
+          set -euo pipefail
+          dsh plugin --profile smoke remove "${BUNDLE}"
+          profile="${HOME}/.dsh/profiles/smoke"
+          if grep -q "${BUNDLE}" "${profile}/package.json"; then
+            echo "После remove бандл остался в профиле."
+            exit 1
+          fi
+          echo "Профиль вернулся в исходное состояние."
+
+  published:
+    name: Команда установки из README работает
+    # Тянет код с GitHub, поэтому в обычных прогонах не нужна: на ветке
+    # проверяется рабочее дерево. Недельный прогон ловит две вещи: свежая
+    # версия dsh сломала бандл, либо опубликованная команда перестала работать.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        dsh: ['0.1.0-rc.6', 'latest']
+    steps:
+      - name: pnpm на PATH и dsh ${{ matrix.dsh }}
+        run: |
+          set -euo pipefail
+          npm install -g pnpm@10
+          npm install -g "@deepseek-ai/dsh@${{ matrix.dsh }}"
+          echo "dsh $(dsh --version), pnpm $(pnpm --version)"
+
+      - name: Установка ровно той командой, что стоит в README
+        run: dsh plugin --profile smoke add "github:Vladimir-Human/humanizer-ru#path:/dsh"
+
+      - name: Бандл стал слоем профиля, файлы на месте
+        run: |
+          set -euo pipefail
+          profile="${HOME}/.dsh/profiles/smoke"
+          python3 -c "import json,sys; d=json.load(open(sys.argv[1],encoding='utf-8')); b=d['dsh']['profile']['bundles']; print('bundles:', b); sys.exit(0 if sys.argv[2] in b else 1)" "${profile}/package.json" "${BUNDLE}"
+          test -f "${profile}/node_modules/${BUNDLE}/${SKILL_PATH}"
+          echo "Опубликованная команда работает на dsh ${{ matrix.dsh }}."

--- a/README.en.md
+++ b/README.en.md
@@ -74,6 +74,16 @@ mkdir -p ~/.agents/skills
 git clone --branch v3.13.0 --depth 1 https://github.com/Vladimir-Human/humanizer-ru.git ~/.agents/skills/humanizer-ru
 ```
 
+The second way is the bundle in the `dsh/` subdirectory, installed by the plugin manager. The profile is created on first use, and `pnpm` must be on PATH:
+
+```sh
+dsh plugin --profile web add "github:Vladimir-Human/humanizer-ru#path:/dsh"
+```
+
+The bundle carries a copy of `SKILL.md` and `references/`; the `check_bundle_sync.py` gate keeps it equal to the source. To remove it: `dsh plugin --profile web remove humanizer-ru-dsh`.
+
+The command tracks the default branch. Pinning a tag and a subdirectory in one spec does not work, and it fails silently: `pnpm` drops the subdirectory, installs the whole repository as a plain dependency and exits 0, leaving the profile without the layer. Verified on dsh 0.1.0-rc.6.
+
 dsh search precedence (nearest directory wins): `<project>/.dsh/skills`, `<project>/.agents/skills`, `~/.dsh/skills`, `~/.agents/skills`. dsh never scans `~/.claude/skills`: a skill installed there via the Claude Code steps above stays invisible to dsh.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ mkdir -p ~/.agents/skills
 git clone --branch v3.13.0 --depth 1 https://github.com/Vladimir-Human/humanizer-ru.git ~/.agents/skills/humanizer-ru
 ```
 
+Второй способ — бандл из подкаталога `dsh/`. Его ставит менеджер плагинов, профиль создаётся при первом обращении, `pnpm` нужен на PATH:
+
+```sh
+dsh plugin --profile web add "github:Vladimir-Human/humanizer-ru#path:/dsh"
+```
+
+В бандле лежит копия `SKILL.md` и `references/`; гейт `check_bundle_sync.py` держит её равной источнику. Снять бандл: `dsh plugin --profile web remove humanizer-ru-dsh`.
+
+Команда берёт ветку по умолчанию. Закрепить тег и подкаталог одной строкой не выходит: `pnpm` молча отбрасывает подкаталог, ставит репозиторий целиком обычной зависимостью и возвращает 0, а профиль остаётся без слоя. Проверено на dsh 0.1.0-rc.6.
+
 Порядок поиска скилла в dsh (ближайший каталог побеждает): `<проект>/.dsh/skills`, `<проект>/.agents/skills`, `~/.dsh/skills`, `~/.agents/skills`. Каталог `~/.claude/skills` dsh не сканирует: скилл, установленный туда по инструкции для Claude Code выше, в dsh не виден.
 
 ## Использование


### PR DESCRIPTION
Две дыры, найденные при независимой ревизии публикации.

## 1. В репозитории не было команды установки бандла

Запись в реестре плагинов ведёт на подкаталог `dsh/`, а сайт реестра выводит `dsh plugin add` из `/tree/`-ссылки. То есть команду пользователь получал на стороне, приходил в репозиторий и не находил там о ней ни слова: раздел про dsh описывал только копирование скилла в `~/.agents/skills`. Поиск по всему репозиторию давал ноль вхождений `dsh plugin`.

Обе витрины теперь описывают оба способа.

## 2. Установку бандла не проверял ни один гейт

Из 36 гейтов её не покрывал ни один, и по устройству: бандл ставит менеджер плагинов dsh, а не тесты проекта. Поломку поймали бы вручную и с задержкой, при том что dsh это developer preview с обещанными ломающими изменениями.

Новый workflow:

- **на ветке и в PR** ставит бандл из рабочего дерева, сверяет строку в `dsh.profile.bundles`, наличие `cordis.patch.yml` и вендорной копии `SKILL.md`, прогоняет `check_bundle_sync.py`, затем проверяет, что `remove` возвращает профиль в исходное состояние;
- **раз в неделю** ставит бандл ровно той командой, что стоит в README, на закреплённой версии dsh и на `latest`.

## Почему гейт не смотрит на код возврата

Замер, из-за которого утверждение построено на составе `bundles`:

```
dsh plugin --profile pintest add "github:Vladimir-Human/humanizer-ru#v3.13.0&path:/dsh"
-> exit 0
-> dependencies: { "humanizer-ru#v3.13.0": "github:Vladimir-Human/humanizer-ru#v3.13.0" }
-> dsh.profile.bundles: [ "@deepseek-ai/dsh-base" ]
-> dsh: warning: declares no dsh.bundle - installed as a plain dependency, not a profile layer
```

`pnpm` молча отбросил `&path:/dsh` и поставил репозиторий целиком обычной зависимостью. Установка «прошла» с кодом 0, слоя в профиле нет, скилл не работает. Этот случай описан в обеих витринах, чтобы никто не пытался закрепить тег такой строкой.

## Проверено локально

- `python scripts/check_all.py` -> **36 гейтов, FAIL: 0, SKIP: 0**
- `check_own_style.py`: README.md 69 из 90, README.en.md 32 из 90
- ограды кода чётные: 16 и 18
- YAML нового workflow парсится, UTF-8 без BOM
- установка с GitHub опубликованной командой: exit 0, `humanizer-ru-dsh` в `dsh.profile.bundles`, файлы на месте; тестовые профили удалены

`pnpm` на runner'е ставится явно: dsh вызывает `spawnSync("pnpm", ...)` и без него печатает `pnpm not found on PATH`.
