### PR TITLE
SKILL.md: last_reviewed 2026-09-03 (релизный коммит лёг за полночью)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ compatibility: DeepSeek Harness (dsh), Claude.ai, Claude Code, opencode и др�
 metadata:
   author: Vladimir-Human
   version: "3.16.10"
-  last_reviewed: "2026-09-02"
+  last_reviewed: "2026-09-03"
   next_review_due: "2026-11-12"
   tags: "writing, editing, russian, ai-cleanup, humanizer"
   documentation: "https://github.com/Vladimir-Human/humanizer-ru#readme"

--- a/dsh/skills/humanizer-ru/SKILL.md
+++ b/dsh/skills/humanizer-ru/SKILL.md
@@ -7,7 +7,7 @@ compatibility: DeepSeek Harness (dsh), Claude.ai, Claude Code, opencode и др�
 metadata:
   author: Vladimir-Human
   version: "3.16.10"
-  last_reviewed: "2026-09-02"
+  last_reviewed: "2026-09-03"
   next_review_due: "2026-11-12"
   tags: "writing, editing, russian, ai-cleanup, humanizer"
   documentation: "https://github.com/Vladimir-Human/humanizer-ru#readme"


### PR DESCRIPTION
Гейт skill-reviewed сравнивает last_reviewed с датой последнего коммита SKILL.md/references. Коммит выпуска 3.16.10 создан в 00:03 MSK 2026-09-03, поэтому last_reviewed 2026-09-02 на теге оказался старее даты коммита и релизный чек-лист покраснел. Правка: last_reviewed 2026-09-03 в обоих синхронных копиях SKILL.md. Содержимое версии 3.16.10 не меняется; sdist/wheel PyPI не содержат SKILL.md (проверено), артефакты PyPI 3.16.10 остаются в силе.