### PR TITLE
Pages: артефакт со скрытыми файлами — /.well-known/llms.txt отдавал 404

### DIFF
--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -52,9 +52,15 @@ jobs:
           cp eval/facts/facts.v1.json demo/eval/facts/facts.v1.json
           cp llms.txt demo/.well-known/llms.txt
       - name: Собрать артефакт из demo/
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        # upload-artifact напрямую (а не upload-pages-artifact) с
+        # include-hidden-files: скрытые пути (.well-known/, .nojekyll)
+        # иначе вырезаются из артефакта и Pages отдаёт 404 на
+        # /.well-known/llms.txt — конвенция машинного входа ломается.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
+          name: github-pages
           path: demo
+          include-hidden-files: true
       - name: Опубликовать
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
Восстановление критерия (а) hotfix v3.16.11: upload-pages-artifact вырезал скрытые пути, /.well-known/llms.txt и .nojekyll не доезжали до Pages (404), live-гейт demo-pages падал. Замена на upload-artifact (тот же пин v7, что в link-check/release-check) с include-hidden-files: true и именем github-pages для deploy-pages. Состав копий и шаг --live-pages без изменений; статический гейт check_pages_router зелёный локально. Относится к patch-группе v3.16.11 (восстановление обещанного), тег ставится после этого мержа.