### PR TITLE
fix(status): деплой-чекаут с тегами, published_tag null вместо пустой строки

### DIFF
--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -38,6 +38,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0  # теги нужны write_status для честного лага
       - name: Настроить Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Добавить машинные файлы к артефакту

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ humanizer-markers --scan primer.txt
 - [Модель угроз и границы детектора](docs/THREAT-MODEL.md).
 - [Парити-гейт Python и JS правил](.github/workflows/regex-check.yml).
 - [Самоаудит: числа, статусы и эррата](eval/facts/self-audit.v1.json).
-- Статус последнего успешного прогона main: [docs/status.json](docs/status.json) (обновляется только зелёным прогоном).
+- Статус последнего успешного прогона и деплоя: [status.json на Pages](https://vladimir-human.github.io/humanizer-ru/status.json) (генерируется деплой-артефактом из точного SHA; обновляется только зелёным прогоном).
 
 ## Установка скилла в браузерные клиенты
 

--- a/scripts/write_status.py
+++ b/scripts/write_status.py
@@ -51,6 +51,8 @@ def main(argv=None):
         tag = best[1]
     published = None
     lag = None
+    if not tag:
+        tag = None
     if tag:
         published = subprocess.run(["git", "rev-parse", "--short", tag],
                                    capture_output=True, text=True,


### PR DESCRIPTION
## Что изменилось для пользователя

Строка статуса в футере демо после деплоя показывает фактический лаг main относительно последнего релизного тега (или «main совпадает с релизом»), вместо «сведений о релизе нет», которое возникало из-за чекаута без тегов в demo-pages.

## Исходное воспроизведение

Live /status.json после деплоя aada3bf: published_tag пустая строка, lag_commits null при опубликованном v3.32.0 — чекаут demo-pages имел fetch-depth 1 и не видел тегов.

## Отрицательные тесты

check_demo_states --selftest 4/4 (включая темп-репозиторий без тегов: null; с тегом: целое). Поведение write_status при отсутствии тегов не изменилось (null), пустая строка заменена null.

## Полный прогон

quick зелёный на ветке; полный check_all — комментарием перед merge.

## Влияние на контракт и поставки

Только workflow и сериализация статуса; контракт/CLI/MCP не тронуты.