### PR TITLE
publish-mcp: фактическое имя ассета mcp-publisher

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -46,10 +46,12 @@ jobs:
 
       - name: Установить mcp-publisher
         run: |
+          # Имена ассетов релиза реестра: mcp-publisher_<os>_<arch>.tar.gz
+          # (проверено по asset-ам releases/latest 2026-09-07).
           curl -sSL -o mcp-publisher.tar.gz \
-            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
           tar xzf mcp-publisher.tar.gz mcp-publisher
-          ./mcp-publisher --version || true
+          ./mcp-publisher --version
 
       - name: Аутентификация GitHub OIDC
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION
Прогон publish-mcp.yml упал на установке: ассеты релиза modelcontextprotocol/registry называются `mcp-publisher_<os>_<arch>.tar.gz` (проверено по `gh api repos/modelcontextprotocol/registry/releases/latest`), а не через дефис с версией. URL исправлен по фактическим именам ассетов; `--version || true` заменён на строгую проверку установки.