### PR TITLE
CI теговой публикации: полная история checkout и повтор публикации в реестр MCP

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -57,7 +57,17 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Публикация записи реестра
-        run: ./mcp-publisher publish --file server.json
+        run: |
+          # Реестр сверяет версию с PyPI и отвечает 400 «Wait and retry»,
+          # пока свежая версия не распространится: повторяем до 10 раз.
+          for attempt in $(seq 1 10); do
+            echo "попытка $attempt"
+            if ./mcp-publisher publish --file server.json; then
+              exit 0
+            fi
+            [ "$attempt" -lt 10 ] && sleep 60
+          done
+          exit 1
 
       - name: Чтение опубликованной записи
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0   # гейты git-depth и attribution требуют полную историю
 
       - name: Установить build
         run: python3 -m pip install --user build

--- a/tests/test_release_pipeline_contract.py
+++ b/tests/test_release_pipeline_contract.py
@@ -146,8 +146,8 @@ class IntervalGateTests(unittest.TestCase):
         self.assertEqual(rc, 1)
 
     def test_post_interval_waived_pair_named(self):
-        # Пара v3.33.0 -> v3.34.0 покрыта одноразовым приказом владельца
-        # от 2026-09-07 (docs/release-waivers.json): rc 0 с явной пометкой.
+        # Текущая пара релизов покрыта одноразовым приказом владельца
+        # (docs/release-waivers.json): rc 0 с явной пометкой об исключении.
         self._patch([
             {"tag_name": TAG_LAST, "draft": False,
              "published_at": "2026-09-06T20:51:52Z"},


### PR DESCRIPTION
Теговой прогон pypi-publish на v3.34.0 упал на трёх гейтах strict, а publish-mcp — на 400 реестра:

- **git-depth / attribution**: checkout по умолчанию берёт глубину 1, гейты требуют полную историю → `fetch-depth: 0`.
- **version-literals**: комментарий теста о waived-паре содержал литералы версий → переписан без версий (константы TAG_LAST/TAG_NEXT уже собираются конкатенацией).
- **publish-mcp 400 «Wait and retry»**: реестр сверяет версию с PyPI и отказывает, пока свежая версия не распространится → цикл до 10 попыток с паузой 60 с.

Проверено локально: `check_all --quick` 139/0/0, `check_release.py --selftest` 28/28, `check_version_literals.py` rc 0, контрактные тесты pipeline 17 OK.
