### PR TITLE
release-check: установка build перед строгим прогоном

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Установить build
+        # Гейты pypi-metadata и sdist-теста в --strict обязаны выполняться,
+        # а не SKIP: без модуля build они не проверены и блокируют прогон.
+        run: python3 -m pip install --user build
+
       - name: Релизный тег (явный input, ref или последний v*)
         id: tag
         run: |


### PR DESCRIPTION
Первый фактический прогон `release-check.yml` после восстановления парсимости файла (run 34107624802) показал: `check_all.py --strict` блокируется двумя SKIP — `pypi-metadata` и `sdist -> чистое venv` требуют модуль `build`, которого нет в job. До этого workflow падал на старте (YAML), поэтому связка «--strict без установленного build» ни разу не исполнялась.

**Изменение:** шаг `Установить build` (`python3 -m pip install --user build`) после checkout — так же, как в `pypi-publish.yml`, где полный strict с этими гейтами зелёный (run 34104815270).

Проверено: `check_action_yaml.py` rc 0 (16 файлов), контрактные тесты pipeline 19 OK, `check_all --quick` 139/0/0.
