### PR TITLE
self-audit: перезапись отчёта после записей отмены правила интервала

### DIFF
--- a/eval/facts/self-audit.v1.json
+++ b/eval/facts/self-audit.v1.json
@@ -2,7 +2,7 @@
   "registry": "humanizer-ru self-audit: самоприменение детерминированного слоя к публичным файлам поставки",
   "version": "3.35.0",
   "date": "2026-09-08",
-  "measured_commit": "ca8cc0f715c3b98938673c843ab6a8f1d15d553e",
+  "measured_commit": "3abdbd4ecc0c8fa693a30389d7440070384709e2",
   "commit_note": "числа измерены на рабочем дереве; отчёт-committed рядом с измеряемыми правками — сам отчёт в скоуп измерения не входит, поэтому числа соответствуют дереву коммита, содержащего отчёт",
   "scope_files": 43,
   "methods": {
@@ -167,7 +167,7 @@
       "markers_b": 0,
       "scan_features": 0,
       "scan_categories": 0,
-      "style_total": 28,
+      "style_total": 30,
       "detect_status": "not-validated",
       "detect_genre": "prose",
       "detect_note": "значения сравниваются только в пределах заявленного домена; вердикт об авторстве не выносится"
@@ -178,7 +178,7 @@
       "markers_b": 0,
       "scan_features": 0,
       "scan_categories": 0,
-      "style_total": 52,
+      "style_total": 51,
       "detect_status": "not-validated",
       "detect_genre": "prose",
       "detect_note": "значения сравниваются только в пределах заявленного домена; вердикт об авторстве не выносится"


### PR DESCRIPTION
Продолжение #158: гейт self-audit поймал устаревший отчёт самоприменения после правки GOVERNANCE.md и AGENTS.md (записи отмены правила интервала). Отчёт перезаписан штатным генератором. Проверки: check_all --quick и полный strict — в комментарии перед merge.