### PR TITLE
glama.json: maintainer-заявка для актуализации листинга Glama

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "Vladimir-Human"
+  ]
+}


### PR DESCRIPTION
Карточка humanizer-ru в каталоге Glama несёт устаревший снимок: страница схемы показывает 6 инструментов (humanizer_clean отсутствует) при 7 в поставке и в официальном реестре MCP (3.35.1, active, isLatest, tools/list 7 — проверено установкой по записи реестра). Последняя инспекция каталога — до добавления humanizer_clean (Protocol revision 2025-11-25 на странице схемы; датированные снапшоты — в журнале сопровождения). Документированный механизм каталога (страница Admin листинга): glama.json в корне репозитория с GitHub-аккаунтом в maintainers заявляет управление без формы; каталог признаёт заявителя на ближайшей синхронизации, после чего доступен запрос ре-синхронизации вместо ожидания планового обхода. Данные каталога, продукт не изменяется; stdlib-only не затрагивается. Проверки: check_all --quick — 144 гейта, FAIL 0, SKIP 0.