### PR TITLE
Harden release contracts, MCP installation, and entry-point gates

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -11,6 +11,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Проверяемый annotated тег выпуска'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -28,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Версия server.json равна версии пакета
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,6 +15,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Проверяемый annotated тег выпуска'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -32,6 +37,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0   # гейты git-depth и attribution требуют полную историю
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Установить build
         run: python3 -m pip install --user build

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -12,8 +12,8 @@ on:
                        # гонка «тег раньше Release» не требует пересоздания тега
     inputs:
       tag:
-        description: 'Проверяемый тег (по умолчанию последний v*)'
-        required: false
+        description: 'Проверяемый annotated тег выпуска'
+        required: true
         type: string
 
 permissions:
@@ -33,18 +33,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref_name }}
 
       - name: Установить build
         # Гейты pypi-metadata и sdist-теста в --strict обязаны выполняться,
         # а не SKIP: без модуля build они не проверены и блокируют прогон.
         run: python3 -m pip install --user build
 
-      - name: Релизный тег (явный input, ref или последний v*)
+      - name: Релизный тег из checkout
         id: tag
         run: |
-          if [[ -n "${{ inputs.tag }}" ]]; then T="${{ inputs.tag }}";
-          elif [[ "$GITHUB_REF_NAME" == v* ]]; then T="$GITHUB_REF_NAME";
-          else T=$(git tag --sort=-v:refname | head -1); fi
+          T="${{ inputs.tag || github.ref_name }}"
+          [[ "$T" == v* ]] || { echo "FAIL: нужен тег vX.Y.Z, получено $T"; exit 1; }
           echo "value=$T" >> "$GITHUB_OUTPUT"
           echo "проверяемый тег: $T"
 

--- a/llms.txt
+++ b/llms.txt
@@ -70,8 +70,9 @@
 - MCP-сервер (Model Context Protocol, stdio): `pip install humanizer-ru`,
   в конфигурации MCP-клиента команда `humanizer-mcp` (без аргументов;
   JSON-RPC 2.0, newline-delimited). Инструменты `humanizer_scan`,
-  `humanizer_markers`, `humanizer_polish`, `humanizer_detect`,
-  `humanizer_facts`, `humanizer_report` — шесть, как в contract.v1.json и
+  `humanizer_markers`, `humanizer_polish`, `humanizer_clean`,
+  `humanizer_detect`, `humanizer_facts`, `humanizer_report` — семь, как в
+  contract.v1.json и
   в ответе `tools/list`; их схемы
   генерируются из contract.v1.json, находка возвращается как успешный
   tool result (isError false), ошибка входа — isError true с конвертом.

--- a/scripts/check_compatibility.py
+++ b/scripts/check_compatibility.py
@@ -99,6 +99,26 @@ def norm(value, key=None):
         return value
     return value
 
+
+SCHEMA_KEYS = {
+    "type", "enum", "const", "required", "additionalProperties",
+    "minItems", "maxItems", "minLength", "maxLength", "pattern",
+    "items", "properties", "anyOf", "oneOf",
+}
+
+def schema_shape(value, key=None):
+    """Сохранить структурные ограничения inputSchema, отбросив описания."""
+    if isinstance(value, dict):
+        return {k: schema_shape(v, k) for k, v in value.items()
+                if k in SCHEMA_KEYS}
+    if isinstance(value, list):
+        out = [schema_shape(v, key) for v in value]
+        if key in ("required", "enum"):
+            return sorted(out, key=repr)
+        return out
+    return value
+
+
 def w(name, text):
     p = os.path.join(T, name)
     with open(p, "w", encoding="utf-8", newline="") as fh:
@@ -174,8 +194,13 @@ try:
     # словаря (допустимо), аддитивный параметр — новый элемент списка
     # props (каждый OLD-элемент обязан иметь типизированную пару в NEW).
     tools_rec = {d["name"]: {
+        # Старые поля сохраняются для читаемого отчёта; полная структурная
+        # форма нужна, чтобы ловить смену type/enum/required, а не только
+        # переименование свойства.
         "props": sorted(d["inputSchema"]["properties"]),
-        "required": sorted(d["inputSchema"]["required"])} for d in defs}
+        "required": sorted(d["inputSchema"]["required"]),
+        "input_schema": schema_shape(d["inputSchema"])}
+        for d in defs}
     out.append({"label": "mcp:tools", "rc": 0, "payload": tools_rec})
     state = {}
     r = ms.handle_message(json.dumps({
@@ -294,6 +319,16 @@ def _compat_problems(old, new, path, key=None) -> list:
                 problems.extend(_compat_problems(old[k], new[k], path, k))
         return problems
     if t_old == "list":
+        if key == "required":
+            old_set, new_set = set(old), set(new)
+            problems = []
+            for item in sorted(old_set - new_set, key=repr):
+                problems.append("%s: обязательное поле %r удалено "
+                                "в новой версии" % (path, item))
+            for item in sorted(new_set - old_set, key=repr):
+                problems.append("%s: добавлено новое обязательное поле %r "
+                                "(ломает старых клиентов)" % (path, item))
+            return problems
         problems = []
         pool = list(new)
         for i, item in enumerate(old):
@@ -317,6 +352,9 @@ def _compat_problems(old, new, path, key=None) -> list:
             else:
                 pool.pop(hit)
         return problems
+    if key == "type" and old != new:
+        return ["%s: поле type: тип OLD=%r NEW=%r"
+                % (path, old, new)]
     if old != new:
         return ["%s: поле %s: OLD=%r NEW=%r" % (path, key or "-", old, new)]
     return []
@@ -630,6 +668,29 @@ def selftest() -> int:
                                            "date_like": True}]}}]
     p, _r, _a = compare(typed_old, typed_added)
     case("добавленное вложенное поле аддитивно", p == [])
+
+    schema_old = [{"label": "mcp:tools", "rc": 0, "payload": {
+        "humanizer_scan": {"required": ["text"], "input_schema": {
+            "type": "object", "required": ["text"],
+            "properties": {"text": {"type": "string"}}}}}}]
+    schema_required = [{"label": "mcp:tools", "rc": 0, "payload": {
+        "humanizer_scan": {"required": ["text", "genre"],
+                            "input_schema": {
+                                "type": "object",
+                                "required": ["text", "genre"],
+                                "properties": {
+                                    "text": {"type": "string"},
+                                    "genre": {"type": "string"}}}}}}]
+    p, _r, _a = compare(schema_old, schema_required)
+    case("новый required-параметр MCP ловится (негатив)",
+         any("обязательное поле" in x for x in p))
+    schema_type = [{"label": "mcp:tools", "rc": 0, "payload": {
+        "humanizer_scan": {"required": ["text"], "input_schema": {
+            "type": "object", "required": ["text"],
+            "properties": {"text": {"type": "integer"}}}}}}]
+    p, _r, _a = compare(schema_old, schema_type)
+    case("смена type MCP ловится (негатив)",
+         any("тип" in x for x in p))
 
     # Новые операции: отсутствует в OLD, присутствует в NEW — аддитивность.
     absent_old = [{"label": "clean:a", "absent": True}]

--- a/scripts/check_contract.py
+++ b/scripts/check_contract.py
@@ -80,19 +80,28 @@ def load_contract() -> dict:
 
 # ------------------------------------------------------------ мини-валидатор
 
-def _type_ok(value, name: str) -> bool:
-    if name == "integer":
-        return isinstance(value, int) and not isinstance(value, bool)
-    if name == "number":
-        return isinstance(value, (int, float)) and not isinstance(value, bool)
-    py = _TYPES.get(name)
-    if py is None:
-        return True  # неизвестный тип не ограничивает
-    if py is bool:
-        return isinstance(value, bool)
-    if py is dict or py is list or py is str:
-        return isinstance(value, py)
-    return isinstance(value, py)
+def _type_ok(value, name) -> bool:
+    """Проверить JSON Schema type, включая массив допустимых типов."""
+    names = name if isinstance(name, list) else [name]
+    if not names or not all(isinstance(item, str) for item in names):
+        return False
+    for item in names:
+        if item == "null" and value is None:
+            return True
+        if item == "integer" and isinstance(value, int) \
+                and not isinstance(value, bool):
+            return True
+        if item == "number" and isinstance(value, (int, float)) \
+                and not isinstance(value, bool):
+            return True
+        py = _TYPES.get(item)
+        if py is not None and isinstance(value, py):
+            return True
+        # Сохраняем прежнюю совместимость с расширением схемы: неизвестный
+        # тип не ограничивает значение, но только если он единственный.
+        if py is None and len(names) == 1:
+            return True
+    return False
 
 
 def schema_errors(value, schema, where: str = "$") -> list[str]:
@@ -110,7 +119,7 @@ def schema_errors(value, schema, where: str = "$") -> list[str]:
     if "enum" in schema and value not in schema["enum"]:
         errors.append("%s: значение %r вне enum %r" % (where, value, schema["enum"]))
     tname = schema.get("type")
-    if tname and not _type_ok(value, tname):
+    if tname is not None and not _type_ok(value, tname):
         errors.append("%s: тип %s, ожидался %s" % (where, type(value).__name__, tname))
         return errors
     if "anyOf" in schema:
@@ -308,6 +317,14 @@ def live_check() -> list[str]:
                               timeout=120, encoding="utf-8", errors="replace",
                               env=env_src, cwd=ROOT)
 
+    def _module_entry(module, cli_args):
+        code = ("from humanizer_ru.%s import main; import sys; "
+                "sys.exit(main(%r))" % (module, cli_args))
+        return subprocess.run([sys.executable, "-X", "utf8", "-c", code],
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              timeout=120, encoding="utf-8", errors="replace",
+                              env=env_src, cwd=ROOT)
+
     proc = _cli_entry("clean_main", ["--json", fixture])
     if proc.returncode not in (0, 1):
         errors.append("humanizer-clean: код %d: %s"
@@ -328,6 +345,35 @@ def live_check() -> list[str]:
                               for e in schema_errors(payload, schema))
             else:
                 errors.append("humanizer-clean: в контракте нет output_schema")
+
+    # Facts/report обязаны проверяться успешным путём тоже. Ранее live probe
+    # проверял только четыре однофайловые команды, поэтому union type
+    # mtld: [number, null] в humanizer-report оставался непокрытым.
+    for command, entry, argv, ok_codes in (
+            ("humanizer-facts", "facts_diff",
+             ["diff", fixture, fixture, "--json"], (0,)),
+            ("humanizer-report", "edit_report",
+             [fixture, fixture, "--json"], (0,))):
+        proc = _module_entry(entry, argv)
+        if proc.returncode not in ok_codes:
+            errors.append("%s: код %d: %s"
+                          % (command, proc.returncode,
+                             proc.stderr.strip()[:200]))
+            continue
+        try:
+            payload = json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            errors.append("%s: вывод не JSON: %r" % (command, exc))
+            continue
+        if payload.get("tool") != command:
+            errors.append("%s: в конверте чужое имя %r"
+                          % (command, payload.get("tool")))
+        schema = schemas.get(command)
+        if isinstance(schema, dict):
+            errors.extend("%s: %s" % (command, e)
+                          for e in schema_errors(payload, schema))
+        else:
+            errors.append("%s: в контракте нет output_schema" % command)
 
     # out-of-scope: английский и пустой вход — status out-of-scope, код 0.
     with tempfile.TemporaryDirectory(prefix="contract-scope-") as td:
@@ -434,6 +480,18 @@ def live_check() -> list[str]:
         if not ok2:
             errors.append("cli.%s --contract: ожидался контракт из данных "
                           "пакета (код %d)" % (entry, proc.returncode))
+    for module in ("facts_diff", "edit_report", "mcp_server"):
+        code = ("from humanizer_ru.%s import main; import sys; "
+                "sys.exit(main(['--version']))" % module)
+        proc = subprocess.run(
+            [sys.executable, "-X", "utf8", "-c", code],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=60,
+            encoding="utf-8", errors="replace", env=env, cwd=ROOT)
+        ver = proc.stdout.strip()
+        if proc.returncode != 0 or not re.match(r"^\d+\.\d+\.\d+$", ver):
+            errors.append("module.%s --version: ожидалась версия X.Y.Z, "
+                          "получено %r (код %d)"
+                          % (module, ver, proc.returncode))
     # MCP-smoke: сервер отвечает на initialize версией из контракта и несёт
     # четыре инструмента (полное conformance-ядро — scripts/check_mcp.py).
     try:
@@ -504,6 +562,13 @@ def selftest() -> int:
     bad_name = {"tool": "humanizer-scan", "schema": 1, "files": [{"file": "a"}]}
     case("чужое имя инструмента валится (const)",
          any("const" in e for e in schema_errors(bad_name, schema)))
+    nullable = {"type": ["number", "null"]}
+    case("union type number/null принимает null",
+         schema_errors(None, nullable) == [])
+    case("union type number/null принимает число",
+         schema_errors(1.25, nullable) == [])
+    case("union type number/null отвергает строку",
+         bool(schema_errors("1.25", nullable)))
 
     try:
         doc = load_contract()

--- a/scripts/check_live_distribution.py
+++ b/scripts/check_live_distribution.py
@@ -288,7 +288,9 @@ def _registry_checks(loc, opener=None):
     else:
         pkg = pypi_pkgs[0]
         rec["package"] = {"identifier": pkg.get("identifier"),
-                          "version": pkg.get("version")}
+                          "version": pkg.get("version"),
+                          "runtimeHint": pkg.get("runtimeHint"),
+                          "packageArguments": pkg.get("packageArguments")}
         if pkg.get("identifier") != "humanizer-ru":
             problems.append("реестр MCP: идентификатор пакета %r != "
                             "humanizer-ru (чужой пакет)"
@@ -296,6 +298,16 @@ def _registry_checks(loc, opener=None):
         if pkg.get("version") != ver:
             problems.append("реестр MCP: версия пакета %s != локальная %s"
                             % (pkg.get("version"), ver))
+        args = pkg.get("packageArguments") or []
+        launch_values = [a.get("value") for a in args
+                         if isinstance(a, dict)
+                         and a.get("type") == "positional"]
+        if pkg.get("runtimeHint") != "uvx":
+            problems.append("реестр MCP: для pypi runtimeHint обязан быть "
+                            "uvx, получено %r" % pkg.get("runtimeHint"))
+        if "humanizer-mcp" not in launch_values:
+            problems.append("реестр MCP: packageArguments не запускают "
+                            "humanizer-mcp")
     note = ((server.get("_meta") or {})
             .get("io.modelcontextprotocol.registry/publisher-provided")
             or {})
@@ -561,7 +573,11 @@ def selftest():
         "server": {"name": REGISTRY_NAME, "version": ver,
                    "packages": [{"registryType": "pypi",
                                  "identifier": "humanizer-ru",
-                                 "version": ver}],
+                                 "version": ver,
+                                 "runtimeHint": "uvx",
+                                 "packageArguments": [{
+                                     "type": "positional",
+                                     "value": "humanizer-mcp"}]}],
                    "_meta": {
                        "io.modelcontextprotocol.registry/"
                        "publisher-provided": {
@@ -672,6 +688,15 @@ def selftest():
     _r, p, _u = run(m, deep_files=False)
     case("мутант: чужой пакет MCP ловится",
          any("идентификатор" in x for x in p))
+
+    # Мутант 6b: запись активна, но consumer не знает entry point пакета.
+    m = dict(base_map)
+    reg_launcher = json.loads(json.dumps(registry_ok))
+    del reg_launcher["server"]["packages"][0]["packageArguments"]
+    m[REGISTRY] = reg_launcher
+    _r, p, _u = run(m, deep_files=False)
+    case("мутант: MCP без launcher packageArguments ловится",
+         any("packageArguments" in x for x in p))
 
     # Мутант 7: чужое имя записи MCP.
     m = dict(base_map)

--- a/scripts/mcp/humanizer_mcp.py
+++ b/scripts/mcp/humanizer_mcp.py
@@ -839,10 +839,15 @@ def selftest() -> int:
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
         description="MCP-сервер humanizer-ru (stdio, JSON-RPC 2.0, stdlib).")
+    ap.add_argument("--version", action="store_true",
+                    help="напечатать версию пакета и выйти")
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--tools", action="store_true",
                     help="напечатать tools/list JSON и выйти")
     args = ap.parse_args(argv)
+    if args.version:
+        print(package_version())
+        return 0
     if args.selftest:
         return selftest()
     if args.tools:

--- a/server.json
+++ b/server.json
@@ -14,10 +14,16 @@
       "registryType": "pypi",
       "identifier": "humanizer-ru",
       "version": "3.35.1",
-      "runtimeHint": "uv",
+      "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
-      }
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "humanizer-mcp"
+        }
+      ]
     }
   ],
   "_meta": {

--- a/src/humanizer_ru/edit_report.py
+++ b/src/humanizer_ru/edit_report.py
@@ -206,6 +206,12 @@ SHORT_RU = "Проверяемая гигиена вставки из чата �
 
 
 def main(argv=None):
+    raw = list(sys.argv[1:] if argv is None else argv)
+    divider = raw.index("--") if "--" in raw else len(raw)
+    if "--version" in raw[:divider]:
+        from humanizer_ru import __version__
+        print(__version__)
+        return 0
     ap = argparse.ArgumentParser(prog="humanizer-report")
     ap.add_argument("before")
     ap.add_argument("after")

--- a/src/humanizer_ru/facts_diff.py
+++ b/src/humanizer_ru/facts_diff.py
@@ -555,6 +555,12 @@ def _scope_note(text: str) -> str:
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
+    raw = list(sys.argv[1:] if argv is None else argv)
+    divider = raw.index("--") if "--" in raw else len(raw)
+    if "--version" in raw[:divider]:
+        from humanizer_ru import __version__
+        print(__version__)
+        return 0
     parser = argparse.ArgumentParser(
         prog=TOOL, description="Сверка фактов двух версий текста (F1).")
     sub = parser.add_subparsers(dest="cmd")

--- a/src/humanizer_ru/mcp_server.py
+++ b/src/humanizer_ru/mcp_server.py
@@ -839,10 +839,15 @@ def selftest() -> int:
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
         description="MCP-сервер humanizer-ru (stdio, JSON-RPC 2.0, stdlib).")
+    ap.add_argument("--version", action="store_true",
+                    help="напечатать версию пакета и выйти")
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--tools", action="store_true",
                     help="напечатать tools/list JSON и выйти")
     args = ap.parse_args(argv)
+    if args.version:
+        print(package_version())
+        return 0
     if args.selftest:
         return selftest()
     if args.tools:

--- a/tests/test_installed_user_journeys.py
+++ b/tests/test_installed_user_journeys.py
@@ -148,7 +148,9 @@ class DeveloperJourneyTests(unittest.TestCase):
             self.assertTrue(os.path.isfile(exe),
                             "нет точки входа %s" % t["command"])
         for name in ("humanizer-scan", "humanizer-markers",
-                     "humanizer-polish", "humanizer-detect"):
+                     "humanizer-polish", "humanizer-detect",
+                     "humanizer-clean", "humanizer-facts",
+                     "humanizer-report", "humanizer-mcp"):
             proc = run(console_exe(name), ["--version"])
             self.assertEqual(proc.returncode, 0, name)
             self.assertRegex(proc.stdout.strip(), r"^\d+\.\d+\.\d+$")

--- a/tests/test_mcp_conformance.py
+++ b/tests/test_mcp_conformance.py
@@ -6,7 +6,7 @@
 (матрица поддерживаемых и неподдерживаемая), capabilities, framing
 (newline-delimited, уведомления без ответа), семантика ошибок JSON-RPC
 (-32700/-32600/-32601/-32602), cancellation, tools/list = схемам из
-контракта, tools/call для всех четырёх инструментов: находка (CLI-код 1)
+контракта, tools/call для всех семи инструментов: находка (CLI-код 1)
 — успешный tool result, structuredContent соответствует outputSchema
 контракта (мини-валидатор check_contract), out-of-scope, режимы polish,
 словари жанров.
@@ -245,6 +245,33 @@ class TestMcpTools(unittest.TestCase):
         self.assertEqual(sc["files"][0]["genre"], "prose")
         self.assertEqual(self.schema_errors(sc, self._schema("humanizer_detect")),
                          [])
+
+    def test_facts_success_matches_schema(self):
+        resps, _ = _session([_INIT, _req(2, "tools/call", {
+            "name": "humanizer_facts",
+            "arguments": {
+                "text_before": "В 2024 году было 3 заявки.",
+                "text_after": "В 2024 году было 3 заявки."
+            }})])
+        r = resps[1]["result"]
+        self.assertIs(r["isError"], False)
+        self.assertEqual(
+            self.schema_errors(r["structuredContent"],
+                               self._schema("humanizer_facts")), [])
+
+    def test_report_success_with_nullable_mtld_matches_schema(self):
+        resps, _ = _session([_INIT, _req(2, "tools/call", {
+            "name": "humanizer_report",
+            "arguments": {
+                "text_before": "Короткий русский текст.",
+                "text_after": "Короткий русский текст."
+            }})])
+        r = resps[1]["result"]
+        self.assertIs(r["isError"], False)
+        self.assertIsNone(r["structuredContent"]["files"][0]["mtld"]["before"])
+        self.assertEqual(
+            self.schema_errors(r["structuredContent"],
+                               self._schema("humanizer_report")), [])
 
     def test_marker_class_param(self):
         text = ":contentReference[oaicite:1]{index=1} и ассистентом\u200b"

--- a/tests/test_release_pipeline_contract.py
+++ b/tests/test_release_pipeline_contract.py
@@ -57,6 +57,13 @@ class WorkflowBindingTests(unittest.TestCase):
         self.assertIn("workflow_dispatch", self.rc)
         self.assertIn("inputs:", self.rc)
         self.assertIn("inputs.tag", self.rc)
+        self.assertIn("required: true", self.rc)
+        self.assertIn("ref: ${{ inputs.tag || github.ref_name }}", self.rc)
+
+    def test_publish_workflows_checkout_selected_tag(self):
+        self.assertIn("inputs.tag", self.pp)
+        self.assertIn("required: true", self.pp)
+        self.assertIn("ref: ${{ inputs.tag || github.ref_name }}", self.pp)
 
     def test_publish_needs_verified_build(self):
         self.assertIn("needs: build-and-test", self.pp)


### PR DESCRIPTION
## Что изменено

- `check_contract.py` поддерживает JSON Schema union types, включая `type: ["number", "null"]`.
- Live contract gate проверяет успешные `humanizer-facts` и `humanizer-report` конверты.
- MCP compatibility probe сохраняет структурные input schemas и ловит смену type/enum/required; новый required-параметр блокируется.
- Добавлены регрессии для nullable MTLD и facts/report MCP conformance.
- `server.json` объявляет `uvx` и positional launcher `humanizer-mcp`; live distribution selftest ловит отсутствие launcher mapping.
- Все восемь console entry points, включая facts/report/mcp, поддерживают `--version`; installed journey проверяет полный список.
- `llms.txt` перечисляет полный набор из семи MCP-инструментов.
- Release-check, PyPI и MCP publish проверяют выбранный annotated tag через `checkout.ref`; manual dispatch требует `inputs.tag`.

## Проверка

- `python scripts/check_contract.py --selftest` — 13/13 PASS.
- `python scripts/check_contract.py` — PASS.
- `python scripts/check_compatibility.py --selftest` — 22/22 PASS.
- `python scripts/check_compatibility.py` — 3.35.0 -> 3.35.1, rc 0.
- `python scripts/check_live_distribution.py --selftest` — 15/15 PASS.
- `python scripts/check_attribution.py` — PASS.
- `python scripts/check_all.py --quick` — 144/144 PASS.
- `python -m unittest discover -s tests` — 474 tests, OK, 12 штатных skip.
- MCP conformance — 15 tests, OK.

Автономные коммиты: `d57aacc`, `93cbd2f`, `686ff3b` (каждое сообщение содержит `autonomous run`).