### PR TITLE
Release humanizer-ru 3.35.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,13 +3,13 @@
   "name": "humanizer-ru",
   "owner": "Vladimir-Human",
   "description": "Install Humanizer RU as a Claude plugin. | Установка Humanizer RU как плагина Claude.",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "plugins": [
     {
       "name": "humanizer-ru",
       "source": "./",
       "description": "Гигиена вставки из чата для русского текста: детерминированно, офлайн, флаги с причиной и советом. | Verifiable chat-paste hygiene for Russian text: deterministic, backed by a facts registry, offline, every flag with a reason and a fix.",
-      "version": "3.35.1",
+      "version": "3.35.2",
       "license": "MIT",
       "keywords": [
         "humanizer",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "humanizer-ru",
   "displayName": "Humanizer RU",
   "description": "Гигиена вставки из чата для русского текста: детерминированно, офлайн, флаги с причиной и советом. | Verifiable chat-paste hygiene for Russian text: deterministic, backed by a facts registry, offline, every flag with a reason and a fix.",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "author": "Vladimir-Human",
   "homepage": "https://github.com/Vladimir-Human/humanizer-ru",
   "repository": "https://github.com/Vladimir-Human/humanizer-ru",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "humanizer-ru",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "description": "Гигиена вставки из чата для русского текста: детерминированно, офлайн, флаги с причиной и советом. | Verifiable chat-paste hygiene for Russian text: deterministic, backed by a facts registry, offline, every flag with a reason and a fix.",
   "author": "Vladimir-Human",
   "homepage": "https://github.com/Vladimir-Human/humanizer-ru",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "humanizer-ru",
   "displayName": "Humanizer RU",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "description": "Гигиена вставки из чата для русского текста: детерминированно, офлайн, флаги с причиной и советом. | Verifiable chat-paste hygiene for Russian text: deterministic, backed by a facts registry, offline, every flag with a reason and a fix.",
   "author": "Vladimir-Human",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,13 @@
 
 ## 3.35.2 — 2026-09-08
 
-- Исправлены гейты машинного контракта и совместимости: проверяются union-типы JSON Schema, успешные facts/report-конверты и структурные MCP input-схемы; несовместимые required/type изменения блокируются.
-- MCP Registry metadata теперь содержит явный uvx launcher humanizer-mcp; установленный smoke проверяет --version у всех console entry points.
-- Release, PyPI и MCP publish workflows проверяют выбранный annotated tag через checkout ref; llms.txt синхронизирован с семью MCP-инструментами.
+- Исправлены гейты машинного контракта и совместимости: проверяются
+  union-типы JSON Schema, успешные facts/report-конверты и структурные MCP
+  input-схемы; несовместимые required/type изменения блокируются.
+- MCP Registry metadata теперь содержит явный uvx launcher humanizer-mcp;
+  установленный smoke проверяет --version у всех console entry points.
+- Release, PyPI и MCP publish workflows проверяют выбранный annotated tag
+  через checkout ref; llms.txt синхронизирован с семью MCP-инструментами.
 ## 3.35.1 — 2026-09-08
 
 - Выпуск 3.35.1 (патч: публичные metadata и приёмка, поведение продукта

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   стал детерминированным. Актуальный статус пересчитан повторным
   workflow_dispatch.
 
+## 3.35.2 — 2026-09-08
+
+- Исправлены гейты машинного контракта и совместимости: проверяются union-типы JSON Schema, успешные facts/report-конверты и структурные MCP input-схемы; несовместимые required/type изменения блокируются.
+- MCP Registry metadata теперь содержит явный uvx launcher humanizer-mcp; установленный smoke проверяет --version у всех console entry points.
+- Release, PyPI и MCP publish workflows проверяют выбранный annotated tag через checkout ref; llms.txt синхронизирован с семью MCP-инструментами.
 ## 3.35.1 — 2026-09-08
 
 - Выпуск 3.35.1 (патч: публичные metadata и приёмка, поведение продукта

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
 repository-code: "https://github.com/Vladimir-Human/humanizer-ru"
 url: "https://github.com/Vladimir-Human/humanizer-ru"
 license: MIT
-version: 3.35.1
-date-released: "2026-09-05"
+version: 3.35.2
+date-released: "2026-09-08"
 keywords:
   - agent-skills
   - russian

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -68,7 +68,7 @@ npx skills add https://github.com/Vladimir-Human/humanizer-ru --skill humanizer-
 или клон тега выпуска:
 
 ```sh
-git clone --branch v3.35.1 --depth 1 https://github.com/Vladimir-Human/humanizer-ru.git ~/.claude/skills/humanizer-ru
+git clone --branch v3.35.2 --depth 1 https://github.com/Vladimir-Human/humanizer-ru.git ~/.claude/skills/humanizer-ru
 ```
 
 Попробовать без установки: [онлайн-демо](https://vladimir-human.github.io/humanizer-ru/) —

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: "Read Grep Glob"
 compatibility: DeepSeek Harness (dsh), Claude.ai, Claude Code, opencode и другие агенты с поддержкой agentskills.io. Только текст.
 metadata:
   author: Vladimir-Human
-  version: "3.35.1"
+  version: "3.35.2"
   last_reviewed: "2026-09-08"
   next_review_due: "2026-11-14"
   tags: "writing, editing, russian, ai-cleanup, humanizer"
@@ -16,7 +16,7 @@ metadata:
   sources: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing; https://ru.wikipedia.org/wiki/%D0%92%D0%B8%D0%BA%D0%B8%D0%BF%D0%B5%D0%B4%D0%B8%D1%8F%3A%D0%9F%D1%80%D0%B8%D0%B7%D0%BD%D0%B0%D0%BA%D0%B8_%D1%81%D0%B3%D0%B5%D0%BD%D0%B5%D1%80%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8_%D1%82%D0%B5%D0%BA%D1%81%D1%82%D0%B0; https://en.wikipedia.org/wiki/Wikipedia:WikiProject_AI_Cleanup"
 ---
 
-# Humanizer-ru — очеловечивание текста (v3.35.1)
+# Humanizer-ru — очеловечивание текста (v3.35.2)
 
 Скилл для русского текста со следами машинной генерации: снятие
 машинного слоя и артефактов вставки, стилевая правка по явной просьбе;

--- a/action/action.yml
+++ b/action/action.yml
@@ -46,7 +46,7 @@ inputs:
       Ref проверяемого репозитория для checkout. Пусто — текущий HEAD
       (для pull_request — merge-коммит действия checkout по умолчанию).
       Версия самого экшена закрепляется в строке uses:
-      Vladimir-Human/humanizer-ru/action@v3.35.1.
+      Vladimir-Human/humanizer-ru/action@v3.35.2.
     required: false
     default: ''
 

--- a/agents/openai.yaml
+++ b/agents/openai.yaml
@@ -1,4 +1,4 @@
-version: "3.35.1"
+version: "3.35.2"
 name: humanizer-ru
 interface:
   display_name: "Humanizer RU"

--- a/contract.v1.json
+++ b/contract.v1.json
@@ -4,9 +4,9 @@
   "language": "ru",
   "product": {
     "name": "humanizer-ru",
-    "version": "3.35.1",
+    "version": "3.35.2",
     "install": {
-      "pip": "pip install humanizer-ru==3.35.1",
+      "pip": "pip install humanizer-ru==3.35.2",
       "requires_python": ">=3.9",
       "freshness": "сверьте версию с https://github.com/Vladimir-Human/humanizer-ru/releases/latest или лентой releases.atom"
     },

--- a/demo/index.html
+++ b/demo/index.html
@@ -336,7 +336,7 @@
 </details>
 <footer style="border-top:1px solid var(--line);background:#fff;padding:10px 20px;color:#666;font-size:13px;">
   <span id="buildinfo" class="rule"></span>
-  humanizer-ru v3.35.1 · демо детерминированного слоя проверки вставки; переписывание и детектор связок — в
+  humanizer-ru v3.35.2 · демо детерминированного слоя проверки вставки; переписывание и детектор связок — в
   <a href="https://github.com/Vladimir-Human/humanizer-ru">репозитории</a> и
   <a href="https://pypi.org/project/humanizer-ru/">PyPI</a>. Машинные файлы:
   <a href="https://github.com/Vladimir-Human/humanizer-ru/blob/main/llms.txt">llms.txt</a> ·

--- a/dsh/package.json
+++ b/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "humanizer-ru-dsh",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "description": "Agent Skill. Verifiable chat-paste hygiene for Russian text: deterministic, backed by a facts registry, offline, every flag with a reason and a fix. Style rewriting only on explicit request; 40 regex markers with an evidence registry.",
   "license": "MIT",
   "author": "Vladimir-Human",

--- a/dsh/skills/humanizer-ru/SKILL.md
+++ b/dsh/skills/humanizer-ru/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: "Read Grep Glob"
 compatibility: DeepSeek Harness (dsh), Claude.ai, Claude Code, opencode и другие агенты с поддержкой agentskills.io. Только текст.
 metadata:
   author: Vladimir-Human
-  version: "3.35.1"
+  version: "3.35.2"
   last_reviewed: "2026-09-08"
   next_review_due: "2026-11-14"
   tags: "writing, editing, russian, ai-cleanup, humanizer"
@@ -16,7 +16,7 @@ metadata:
   sources: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing; https://ru.wikipedia.org/wiki/%D0%92%D0%B8%D0%BA%D0%B8%D0%BF%D0%B5%D0%B4%D0%B8%D1%8F%3A%D0%9F%D1%80%D0%B8%D0%B7%D0%BD%D0%B0%D0%BA%D0%B8_%D1%81%D0%B3%D0%B5%D0%BD%D0%B5%D1%80%D0%B8%D1%80%D0%BE%D0%B2%D0%B0%D0%BD%D0%BD%D0%BE%D1%81%D1%82%D0%B8_%D1%82%D0%B5%D0%BA%D1%81%D1%82%D0%B0; https://en.wikipedia.org/wiki/Wikipedia:WikiProject_AI_Cleanup"
 ---
 
-# Humanizer-ru — очеловечивание текста (v3.35.1)
+# Humanizer-ru — очеловечивание текста (v3.35.2)
 
 Скилл для русского текста со следами машинной генерации: снятие
 машинного слоя и артефактов вставки, стилевая правка по явной просьбе;

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,5 +1,5 @@
 {
   "name": "humanizer-ru",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "description": "Гигиена вставки из чата для русского текста: детерминированно, офлайн, флаги с причиной и советом. | Verifiable chat-paste hygiene for Russian text: deterministic, backed by a facts registry, offline, every flag with a reason and a fix."
 }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Vladimir-Human/humanizer-ru",
   "title": "humanizer-ru",
   "description": "Гигиена вставки из чата для русского текста: детерминированно, офлайн, флаги с причиной и советом.",
-  "version": "3.35.1",
+  "version": "3.35.2",
   "websiteUrl": "https://github.com/Vladimir-Human/humanizer-ru",
   "repository": {
     "url": "https://github.com/Vladimir-Human/humanizer-ru",
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "humanizer-ru",
-      "version": "3.35.1",
+      "version": "3.35.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
@@ -29,7 +29,7 @@
   "_meta": {
     "io.modelcontextprotocol.registry/publisher-provided": {
       "note": "Stdlib-only Python package. One stdio MCP server via console entry point humanizer-mcp exposing humanizer_scan, humanizer_markers, humanizer_polish, humanizer_clean, humanizer_detect, humanizer_facts, humanizer_report. JSON-RPC 2.0, newline-delimited stdio; protocol versions 2025-06-18, 2025-03-26, 2024-11-05. Tool schemas generated from contract.v1.json; a contract violation returns rc=2 with the contract envelope as isError:true. Conformance proven against MCP Inspector CLI and the official Python SDK: research/mcp-conformance-protocol.md.",
-      "install": "pip install humanizer-ru==3.35.1 then run humanizer-mcp (or: uvx --from humanizer-ru humanizer-mcp)"
+      "install": "pip install humanizer-ru==3.35.2 then run humanizer-mcp (or: uvx --from humanizer-ru humanizer-mcp)"
     }
   }
 }

--- a/src/humanizer_ru/__init__.py
+++ b/src/humanizer_ru/__init__.py
@@ -7,4 +7,4 @@ check_markers.py, scan_soft_signals.py, polish.py и detect_conj.py.
 Копии байтово синхронизируются гейтом scripts/check_pkg_sync.py.
 """
 __all__ = ["__version__"]
-__version__ = "3.35.1"
+__version__ = "3.35.2"

--- a/src/humanizer_ru/contract.v1.json
+++ b/src/humanizer_ru/contract.v1.json
@@ -4,9 +4,9 @@
   "language": "ru",
   "product": {
     "name": "humanizer-ru",
-    "version": "3.35.1",
+    "version": "3.35.2",
     "install": {
-      "pip": "pip install humanizer-ru==3.35.1",
+      "pip": "pip install humanizer-ru==3.35.2",
       "requires_python": ">=3.9",
       "freshness": "сверьте версию с https://github.com/Vladimir-Human/humanizer-ru/releases/latest или лентой releases.atom"
     },


### PR DESCRIPTION
## Выпуск 3.35.2

Patch-релиз с исправлениями проверок машинного контракта, совместимости MCP, launcher metadata и release workflow. Добавлены `--version` для facts/report/mcp и исправлено полное перечисление MCP-инструментов в `llms.txt`.

## Проверка

До публикации выполняются `check_all.py --strict`, unit tests, sdist/wheel smoke, metadata, compatibility, подпись annotated tag и живые проверки PyPI/MCP Registry/Pages согласно RELEASE.md.

Все изменения — автономный коммит `2b2efa3` с подписью `autonomous run`.