### PR TITLE
Run HOL scanner verify and retain rule report

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -28,6 +28,16 @@ jobs:
         continue-on-error: true
         uses: hashgraph-online/ai-plugin-scanner-action@caba2e96aa8ad2feb6cf6fca52442b52e22e779f # v1.2.635
         with:
+          mode: verify
           plugin_dir: "."
+          format: text
+          output: plugin-scanner-report.txt
           min_score: 80
           fail_on_severity: high
+      - name: Upload scanner report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: hol-plugin-scanner-report
+          path: plugin-scanner-report.txt
+          if-no-files-found: ignore


### PR DESCRIPTION
Corrects the reproducibility workflow to run the exact requested mode: plugin-scanner verify . --format text. The report is written to plugin-scanner-report.txt and uploaded as an artifact even when advisory findings fail the scanner thresholds. Product runtime and release gates are unchanged. Local validation: check_action_yaml and diff check pass.