### PR TITLE
Align onboarding and harden demo supply inputs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -37,10 +37,17 @@ a paste trace, not an error; rc=0 — no traces, rc=2 — input unreadable
 ```json
 {
   "mcpServers": {
-    "humanizer-ru": { "command": "humanizer-mcp" }
+    "humanizer-ru": {
+      "command": "uvx",
+      "args": ["--from", "humanizer-ru==3.35.2", "humanizer-mcp"]
+    }
   }
 }
 ```
+
+The `uvx` form installs the pinned PyPI release and starts the stdio server.
+With a local installation, `pip install humanizer-ru` followed by
+`humanizer-mcp` is equivalent.
 
 ## Matrix of verified capabilities and boundaries
 
@@ -82,7 +89,7 @@ and tests actually verify; boundaries list what a surface does not do.
 - Agent clients supporting agentskills.io (opencode, DeepSeek Harness): unpack the text bundle from the release archive.
 - A browser extension was declined: a new surface (permissions, store review) does not pay off; idea queue — [research/BACKLOG.md](research/BACKLOG.md).
 
-Каталоги: [Glama MCP](https://glama.ai/mcp/servers/Vladimir-Human/humanizer-ru) · [skills.sh](https://www.skills.sh/vladimir-human/humanizer-ru/humanizer-ru).
+Directories: [Glama MCP](https://glama.ai/mcp/servers/Vladimir-Human/humanizer-ru) · [skills.sh](https://www.skills.sh/vladimir-human/humanizer-ru/humanizer-ru).
 
 ## Same-name projects
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,17 @@ rc=1 означает «найдены маркеры» — это ожидае�
 ```json
 {
   "mcpServers": {
-    "humanizer-ru": { "command": "humanizer-mcp" }
+    "humanizer-ru": {
+      "command": "uvx",
+      "args": ["--from", "humanizer-ru==3.35.2", "humanizer-mcp"]
+    }
   }
 }
 ```
+
+Форма `uvx` устанавливает закреплённый выпуск PyPI и запускает stdio-сервер.
+При локальной установке эквивалентны `pip install humanizer-ru` и запуск
+`humanizer-mcp`.
 
 ## Матрица проверенных возможностей и границ
 

--- a/demo/generate_js_rules.py
+++ b/demo/generate_js_rules.py
@@ -177,7 +177,10 @@ def build_js(doc):
             "rules": rules}
     return ("/* Автогенерация из markers.v1.json скриптом generate_js_rules.py. */\n"
             "const HUMANIZER_MARKERS = " +
-            json.dumps(data, ensure_ascii=False, indent=2) + ";" + NL + 'window.HUMANIZER_MARKERS = HUMANIZER_MARKERS;' + NL)
+            json.dumps(data, ensure_ascii=False, indent=2) + ";" + NL
+            + 'if (typeof window !== "undefined") {' + NL
+            + '  window.HUMANIZER_MARKERS = HUMANIZER_MARKERS;' + NL
+            + '}' + NL)
 
 
 def build_sw(js_text, index_text="", engine_text="", sample_text=""):

--- a/demo/index.html
+++ b/demo/index.html
@@ -67,8 +67,8 @@
   </div>
   <div class="cols">
     <section>
-      <h2>Текст</h2>
-      <textarea id="text" placeholder="Вставьте текст, скопированный из чата с ИИ, — покажем следы и объясним каждый. Текст не покидает браузер."></textarea>
+      <h2 id="textHeading">Текст</h2>
+      <textarea id="text" aria-labelledby="textHeading" placeholder="Вставьте текст, скопированный из чата с ИИ, — покажем следы и объясним каждый. Текст не покидает браузер."></textarea>
     </section>
     <section>
       <h2>Совпадения</h2>
@@ -91,6 +91,7 @@
   const onlyA = document.getElementById("onlyA");
   const showAll = document.getElementById("showAll");
   const runBtn = document.getElementById("run");
+  const counts = document.getElementById("counts");
   // Единый объект результата: список, подсветка, строка итога и отчёт
   // строятся из одного вычисления; копирование до завершения debounce
   // пересчитывает результат, а не читает устаревший DOM.

--- a/demo/markers.js
+++ b/demo/markers.js
@@ -530,4 +530,6 @@ const HUMANIZER_MARKERS = {
     }
   ]
 };
-window.HUMANIZER_MARKERS = HUMANIZER_MARKERS;
+if (typeof window !== "undefined") {
+  window.HUMANIZER_MARKERS = HUMANIZER_MARKERS;
+}

--- a/demo/sw.js
+++ b/demo/sw.js
@@ -1,5 +1,5 @@
 /* Автогенерация generate_js_rules.py: кэш версионируется хэшем правил, движка, образца и страницы. */
-const CACHE = "humanizer-ru-4a5f904bc9a4";
+const CACHE = "humanizer-ru-13d2bad5759a";
 const STATIC = ["./", "./index.html", "./brand.css", "./markers.js",
   "./engine.js", "./sample.js", "./favicon.svg", "./manifest.json"];
 self.addEventListener("install", (e) => {

--- a/docs/USAGE.en.md
+++ b/docs/USAGE.en.md
@@ -207,7 +207,7 @@ Short map; details live in the directories themselves:
 - `tests/fixtures/` — marker and polish fixtures.
 - `action/`, `demo/`, `dsh/` — CI action, browser demo, dsh bundle.
 
-The full checklist runs in one command: `python scripts/check_all.py` — 123 gates in the full checklist (112 in --quick). Unit tests: `python -m unittest discover -s tests`.
+The full checklist runs in one command: `python scripts/check_all.py` — 155 gates in the full checklist (144 in --quick). Unit tests: `python -m unittest discover -s tests`.
 
 ## Security
 
@@ -236,4 +236,3 @@ marker cannot be removed: that would be a hole in the detector.
   and per-file licenses: `research/validation/README.md`. Borrowed
   fragments stay under their own licenses; the project MIT covers the
   code and original texts, not third-party inserts.
-

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -279,7 +279,7 @@ docs/THREAT-MODEL.md.
 - `action/`, `demo/`, `dsh/` — CI-экшен, браузерное демо, бандл dsh.
 - `METRICS.md`, `RELEASE.md`, `identity.v1.json`, `server.json` — витрина измерений, регламент выпусков, машиночитаемая идентичность и метаданные MCP-реестра.
 
-Полный чек-лист — одна команда: `python scripts/check_all.py` — 123 гейта полного чек-листа (112 в --quick). Юнит-тесты — `python -m unittest discover -s tests`.
+Полный чек-лист — одна команда: `python scripts/check_all.py` — 155 гейтов полного чек-листа (144 в --quick). Юнит-тесты — `python -m unittest discover -s tests`.
 
 ### Содержательные паттерны
 
@@ -338,4 +338,3 @@ Perplexity `ppl-ai-file-upload` как документированную при
 - Проверочные корпусы `eval/manifest.v1.json` содержат дословные фрагменты
   общественного достояния Wikisource и тексты проекта в регистре
   Википедии/Викиновостей; источники и лицензии — в `research/validation/README.md`; MIT покрывает код и свои тексты.
-

--- a/scripts/check_live_distribution.py
+++ b/scripts/check_live_distribution.py
@@ -162,6 +162,7 @@ def _github_facts(opener=None):
             else:
                 commit = obj.get("sha")
         rec["tag_commit"] = commit
+        rec["release_commit"] = commit
         head = fetch_json(REPO_API + "/commits/main", opener=opener)
         rec["main_head"] = head.get("sha")
     except LiveUnavailable as exc:

--- a/scripts/filemarks/setup_synthid.sh
+++ b/scripts/filemarks/setup_synthid.sh
@@ -6,10 +6,14 @@
 # не является официальным детектором Google. Только оценка, не снятие.
 set -e
 DIR="${1:-$HOME/opt/reverse-SynthID}"
+PINNED_COMMIT="f10efaa7efc75591b4744cc1d885874a79f5f7ee"
 if [ -d "$DIR" ]; then
   echo "уже есть: $DIR (повторный клон пропущен)"
 else
-  git clone --depth 1 https://github.com/aloshdenny/reverse-SynthID "$DIR"
+  # Fetch the exact reviewed revision; cloning the moving default branch would
+  # make this optional helper execute unreviewed third-party code.
+  git clone https://github.com/aloshdenny/reverse-SynthID "$DIR"
+  git -C "$DIR" checkout --detach "$PINNED_COMMIT"
 fi
 echo "дальше: export REVERSE_SYNTHID_DIR=$DIR"
 echo "зависимости внешнего скоринга ставьте в отдельное окружение (numpy/opencv/pywavelets/scikit-learn)"


### PR DESCRIPTION
Improves first-run reliability and evidence: README MCP snippets now match the verified uvx launcher; USAGE gate counts match current 155/144 checks; English catalog label is translated; demo textarea has an accessible name and its counts binding is defined; generated marker export is safe to load outside a browser; live distribution records peeled release_commit; optional SynthID helper checks out a reviewed commit instead of a moving branch. Validation: docs, README parity, demo a11y/parity, live-distribution selftest, Node smoke, and check_all --quick (144/144 PASS).