### PR TITLE
Fix MCP release contract workflow step

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -73,7 +73,6 @@ jobs:
 
       - name: Контракт релиза до OIDC-публикации
         run: python3 scripts/check_release.py --release-contract
-          PY
 
       - name: Установить mcp-publisher
         run: |


### PR DESCRIPTION
Remove a stray heredoc terminator that was parsed as an extra argument to check_release.py, causing the release contract step to fail.