### PR TITLE
Pin CI build and browser tooling

### DIFF
--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -118,6 +118,6 @@ jobs:
         # playwright не поднялся) роняет шаг так же, как FAIL:
         # непроверенное состояние не публикуется как зелёное.
         run: |
-          python3 -m pip install --user playwright
+          python3 -m pip install --user 'playwright==1.62.0'
           python3 -m playwright install --with-deps chromium
           python3 scripts/check_demo_browser.py --url "${{ steps.deployment.outputs.page_url }}index.html"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -60,7 +60,7 @@ jobs:
           PY
 
       - name: Установить build
-        run: python3 -m pip install --user build
+        run: python3 -m pip install --user 'build==1.5.0'
 
       - name: Собрать sdist и wheel
         run: python3 -m build
@@ -107,7 +107,7 @@ jobs:
         # проверенной. Браузерная среда — инфраструктура CI, не runtime
         # продукта (stdlib-only поставка не меняется).
         run: |
-          python3 -m pip install --quiet playwright
+          python3 -m pip install --quiet 'playwright==1.62.0'
           python3 -m playwright install --with-deps chromium
           python3 -m http.server 8478 --directory demo &
           SERVER_PID=$!

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Установить build
         # Гейты pypi-metadata и sdist-теста в --strict обязаны выполняться,
         # а не SKIP: без модуля build они не проверены и блокируют прогон.
-        run: python3 -m pip install --user build
+        run: python3 -m pip install --user 'build==1.5.0'
 
       - name: Релизный тег из checkout
         id: tag


### PR DESCRIPTION
Pin build to 1.5.0 and Playwright to 1.62.0 in release and Pages workflows. This removes package resolver drift from publication and browser gates while keeping product dependencies unchanged.