### PR TITLE
Disable checkout credentials in read-only jobs

### DIFF
--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Подготовка фикстур (маркер класса A + неснимаемый маркер)
         shell: bash

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -42,6 +42,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Самопроверка валидатора
         run: python3 scripts/check_docs.py --selftest
       - name: Проверка репозитория

--- a/.github/workflows/no-anglicisms.yml
+++ b/.github/workflows/no-anglicisms.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Сканировать прозу поставки на чёрный список калек
         run: |

--- a/.github/workflows/offline-core.yml
+++ b/.github/workflows/offline-core.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Установка пакета (до отключения сети)
         run: python3 -m pip install -e .

--- a/.github/workflows/regex-check.yml
+++ b/.github/workflows/regex-check.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Прогнать все выражения по трём уровням образцов
         run: python3 scripts/check_markers.py

--- a/.github/workflows/self-scan.yml
+++ b/.github/workflows/self-scan.yml
@@ -42,6 +42,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Прогнать --scan по всем файлам проекта
         run: |


### PR DESCRIPTION
Set persist-credentials: false on six read-only workflow checkouts. These jobs run repository validation and do not need a token in the local git configuration.