### PR TITLE
Disable credentials in more read-only workflows

### DIFF
--- a/.github/workflows/dsh-install.yml
+++ b/.github/workflows/dsh-install.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: pnpm на PATH и закреплённая версия dsh
         run: |

--- a/.github/workflows/feedback-collect.yml
+++ b/.github/workflows/feedback-collect.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Сборщик внешней обратной связи
         run: |

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -41,6 +41,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Самопроверка гейта (умеет падать)
         run: python3 scripts/check_link_rot.py --selftest
       - name: Формат всех source_url реестра
@@ -53,6 +55,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Найти последний завершившийся прогон этого workflow
         id: source
         env:
@@ -113,8 +117,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Проверка мёртвых ссылок
         run: python3 scripts/check_links.py
-

--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Тесты


### PR DESCRIPTION
Set persist-credentials: false for dsh install, feedback collection, link checks, and status validation checkouts. API access in link checks remains explicit through GH_TOKEN.