### PR TITLE
Disable credentials in publisher checkouts

### DIFF
--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -42,6 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0  # теги нужны write_status для честного лага
       - name: Разрешить SHA деплоя до коммита
         # Для события release github.sha может быть объектом аннотированного

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0   # гейты git-depth и attribution требуют полную историю
           ref: ${{ inputs.tag || github.ref_name }}
 

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout (full history + tags)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ inputs.tag || github.ref_name }}
 


### PR DESCRIPTION
Set persist-credentials: false on Pages, MCP, PyPI, and release-check workflows. These jobs use OIDC or explicit APIs and do not need Git credentials persisted by checkout.