### PR TITLE
Redact contact data from feedback artifacts

### DIFF
--- a/scripts/collect_external_feedback.py
+++ b/scripts/collect_external_feedback.py
@@ -57,6 +57,15 @@ _SIGNAL_PROBLEM = re.compile(
 _SIGNAL_SOLICITATION = re.compile(
     r"(awesome[- ]|add .* to .*(list|repo)|would you be up for|submit"
     r"|star\b|upvote|приглаш|добавьте в каталог)", re.IGNORECASE)
+_EMAIL = re.compile(r"\b[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}\b")
+_URL = re.compile(r"https?://\S+", re.IGNORECASE)
+
+
+def _safe_excerpt(body):
+    """Return a short review hint without copying contact data or URLs."""
+    text = (body or "")[:200].replace("\n", " ")
+    text = _EMAIL.sub("[email]", text)
+    return _URL.sub("[url]", text)
 
 
 def _default_runner(args):
@@ -138,7 +147,7 @@ def _row(author, kind, url, date, title, body="", synthetic=False,
         "signals": sig,
         "concrete_usage_signs": concrete,
         "synthetic": synthetic,
-        "body_excerpt": (body or "")[:200].replace("\n", " "),
+        "body_excerpt": _safe_excerpt(body),
     }
 
 

--- a/tests/test_feedback_collection.py
+++ b/tests/test_feedback_collection.py
@@ -84,6 +84,15 @@ class BodyAndSignalsTests(unittest.TestCase):
         self.assertTrue(com[0]["body_excerpt"])
         self.assertTrue(com[0]["signals"]["has_problem"])
 
+    def test_excerpt_redacts_contact_data_and_urls(self):
+        row = CF._row("reader-external", "issue", "https://github.com/x/y/1",
+                      "2026-09-06", "тест",
+                      body="пишите me@example.org или https://example.org/a")
+        self.assertNotIn("me@example.org", row["body_excerpt"])
+        self.assertNotIn("https://example.org", row["body_excerpt"])
+        self.assertIn("[email]", row["body_excerpt"])
+        self.assertIn("[url]", row["body_excerpt"])
+
 
 @SKIP_OUTSIDE
 class PaginationTests(unittest.TestCase):


### PR DESCRIPTION
Keep feedback signal classification while redacting email addresses and URLs from body excerpts stored in workflow artifacts. Add regression coverage for both redactions.