### PR TITLE
Scope CI permissions to consuming jobs

### DIFF
--- a/.github/workflows/feedback-collect.yml
+++ b/.github/workflows/feedback-collect.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  issues: read
 
 concurrency:
   group: feedback-collect-${{ github.ref }}
@@ -25,6 +24,9 @@ jobs:
     name: Сбор кандидатов и покрытие источников
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -28,7 +28,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
 
 concurrency:
   group: link-check-${{ github.ref }}
@@ -53,6 +52,9 @@ jobs:
     if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
Move issues:read and actions:read from workflow scope to the jobs that actually call the corresponding APIs. Offline validation and artifact jobs retain contents:read only.