### PR TITLE
Document CI result policy for A and B signals

### DIFF
--- a/docs/USAGE.en.md
+++ b/docs/USAGE.en.md
@@ -202,6 +202,14 @@ runs the same scripts, inputs `fail-on: class-a` or `soft-threshold`,
 `permissions: contents: read`, text never leaves the runner. Example:
 `action/action.yml`.
 
+### CI result policy
+
+For a CI owner, the mapping is: class **A** is blocking (fix the artifact and
+rerun the job); class **B** is a non-blocking review/warn (check the context
+manually); `rc=2` is an operational failure (fix the input or path). A and B
+are not authorship verdicts. Synthetic probe lines are in
+`tests/fixtures/ci-policy-cases.md`; machine codes are in `contract.v1.json`.
+
 
 ## Architecture
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -275,6 +275,14 @@ docs/THREAT-MODEL.md.
 `permissions: contents: read`, текст не покидает раннер. Пример вызова — в
 `action/action.yml`.
 
+### Политика CI по результату
+
+Для владельца CI правило простое: класс **A** — blocking (исправить артефакт
+и повторить job); класс **B** — non-blocking review/warn (проверить контекст
+вручную); `rc=2` — operational failure (исправить вход или путь). A и B не
+являются вердиктом об авторстве. Синтетические строки для пробы лежат в
+`tests/fixtures/ci-policy-cases.md`, а машинные коды — в `contract.v1.json`.
+
 
 ## Архитектура
 

--- a/tests/fixtures/ci-policy-cases.md
+++ b/tests/fixtures/ci-policy-cases.md
@@ -1,0 +1,5 @@
+# CI policy fixtures
+
+- `A`: `:contentReference[oaicite:3]{index=3}` → blocking check, исправить и повторить.
+- `B`: контекстный мягкий сигнал → review/warn, решение принимает человек.
+- `rc=2`: файл не читается → operational failure, исправить вход или путь.


### PR DESCRIPTION
Add a concise RU/EN policy card for CI owners: class A blocks, class B requests review, and rc=2 is an operational input failure. Include synthetic fixtures and references to the machine contract.