### PR TITLE
Make CI policy fixture exercise class A

### DIFF
--- a/tests/fixtures/ci-policy-cases.md
+++ b/tests/fixtures/ci-policy-cases.md
@@ -1,5 +1,5 @@
 # CI policy fixtures
 
-- `A`: `:contentReference[oaicite:3]{index=3}` → blocking check, исправить и повторить.
+- A: :contentReference[oaicite:3]{index=3} → blocking check, исправить и повторить.
 - `B`: контекстный мягкий сигнал → review/warn, решение принимает человек.
 - `rc=2`: файл не читается → operational failure, исправить вход или путь.

--- a/tests/test_ci_policy_fixture.py
+++ b/tests/test_ci_policy_fixture.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class CiPolicyFixtureTests(unittest.TestCase):
+    def test_class_a_fixture_is_blocking_signal(self):
+        fixture = os.path.join(ROOT, "tests", "fixtures", "ci-policy-cases.md")
+        proc = subprocess.run(
+            [sys.executable, os.path.join(ROOT, "scripts", "check_markers.py"),
+             "--scan", fixture], capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=30)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("contentReference", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ensure the CI policy fixture contains a detectable class A artifact rather than an inline-code example that is intentionally suppressed. Add a regression test asserting the blocking rc=1 signal.