### PR TITLE
Correct Markdown facts verification recipe

### DIFF
--- a/docs/USAGE.en.md
+++ b/docs/USAGE.en.md
@@ -105,12 +105,15 @@ Package commands:
 
 ### Reproducible Markdown-safe scenario
 
-Use `--preserve-markup` for Markdown: supported traces are removed from prose
-while URLs, numbers and fenced code are preserved. On
-`tests/fixtures/media-markdown-safe.md`, first make a working copy, then run
-`humanizer-markers --scan`, `humanizer-clean --preserve-markup --in-place` and
-`humanizer-facts --no-additions`. This checks only these invariants; it does
-not determine authorship or assess prose quality.
+Use the explicit `humanizer-clean` command for Markdown: supported traces are
+removed while URLs, numbers and fenced code are preserved. On
+`tests/fixtures/media-markdown-safe.md`, first make two working copies named
+`before.md` and `after.md`, then run `humanizer-markers --scan before.md`,
+`humanizer-clean --in-place after.md` and
+`humanizer-facts diff before.md after.md --json`. Numbers inside the removed
+marker are expected losses; check the report for no other losses and confirm
+that the URL and `42` remain. This checks only these invariants; it does not
+determine authorship or assess prose quality.
 
 All four commands read stdin via `-`. Sample output (markers on a chat
 interface line):

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -149,13 +149,15 @@ DeepSeek Harness (dsh): глобально — тот же клон в `~/.agent
 
 ### Воспроизводимый Markdown-safe сценарий
 
-Для Markdown используйте `--preserve-markup`: поддержанные следы в прозе
+Для Markdown используйте явную очистку `humanizer-clean`: поддержанные следы
 снимаются, а URL, числа и fenced-код сохраняются. На фикстуре
-`tests/fixtures/media-markdown-safe.md` сначала сделайте рабочую копию, затем
-выполните `humanizer-markers --scan`, `humanizer-clean --preserve-markup --in-place`
-и
-`humanizer-facts --no-additions`. Сценарий проверяет только эти инварианты;
-он не определяет авторство и не оценивает качество прозы.
+`tests/fixtures/media-markdown-safe.md` сначала сделайте две рабочие копии
+`before.md` и `after.md`, затем выполните `humanizer-markers --scan before.md`,
+`humanizer-clean --in-place after.md` и
+`humanizer-facts diff before.md after.md --json`. Удаление чисел внутри
+самого маркера ожидаемо; в отчёте проверьте, что других потерь нет, а URL и
+число `42` сохранены. Сценарий проверяет только эти инварианты; он не
+определяет авторство и не оценивает качество прозы.
 - `humanizer-markers` — поиск артефактов копипасты, классы A и B;
   `--remove` снимает невидимые метки по классификации риска: safe
   автоматически, ambiguous только opt-in, dangerous никогда; таблица в


### PR DESCRIPTION
Fix the Markdown-safe documentation to use the actual humanizer-facts diff syntax and explain expected loss of numeric marker coordinates while preserving the document URL and number 42. This follows a real local reproduction.