### PR TITLE
Mark mutating MCP tools as destructive

### DIFF
--- a/scripts/mcp/humanizer_mcp.py
+++ b/scripts/mcp/humanizer_mcp.py
@@ -205,7 +205,7 @@ def generate_tool_defs(contract) -> list:
             "annotations": {
                 "readOnlyHint": cmd not in ("humanizer-polish",
                                             "humanizer-clean"),
-                "destructiveHint": False,
+                "destructiveHint": cmd in ("humanizer-polish", "humanizer-clean"),
                 "idempotentHint": True,
                 "openWorldHint": False,
             },

--- a/src/humanizer_ru/mcp_server.py
+++ b/src/humanizer_ru/mcp_server.py
@@ -205,7 +205,7 @@ def generate_tool_defs(contract) -> list:
             "annotations": {
                 "readOnlyHint": cmd not in ("humanizer-polish",
                                             "humanizer-clean"),
-                "destructiveHint": False,
+                "destructiveHint": cmd in ("humanizer-polish", "humanizer-clean"),
                 "idempotentHint": True,
                 "openWorldHint": False,
             },

--- a/tests/test_mcp_conformance.py
+++ b/tests/test_mcp_conformance.py
@@ -188,6 +188,14 @@ class TestMcpTools(unittest.TestCase):
         by = {r.get("id"): r for r in resps}
         self.assertEqual(by[2]["result"]["tools"], self.defs)
 
+    def test_mutating_tools_advertise_destructive_hint(self):
+        annotations = {d["name"]: d["annotations"] for d in self.defs}
+        self.assertTrue(annotations["humanizer_polish"]["destructiveHint"])
+        self.assertTrue(annotations["humanizer_clean"]["destructiveHint"])
+        for name, item in annotations.items():
+            if name not in ("humanizer_polish", "humanizer_clean"):
+                self.assertFalse(item["destructiveHint"], name)
+
     def test_markers_finding_is_success_result(self):
         text = ("Согласно :contentReference[oaicite:12]{index=12}, заявок "
                 "стало больше на 12% — https://example.com/r?utm_source=chatgpt.com")


### PR DESCRIPTION
Set destructiveHint=true for humanizer-polish and humanizer-clean in both MCP server copies. Add conformance coverage while preserving readOnlyHint and all other tool annotations.