### PR TITLE
Scope GitHub Pages permissions to publish job

### DIFF
--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -24,8 +24,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -35,6 +33,10 @@ jobs:
   publish:
     name: Публикация статического демо
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Move pages:write and id-token:write from workflow scope to the publish job. The workflow retains contents:read globally and behavior remains unchanged while reducing permissions for any future jobs.