### PR TITLE
Grant feedback collector discussion read access

### DIFF
--- a/.github/workflows/feedback-collect.yml
+++ b/.github/workflows/feedback-collect.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read
       issues: read
+      discussions: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Add the missing job-level discussions:read permission required by the GraphQL discussions queries in collect_external_feedback.py. This addresses the scheduled run where issues, comments, and discussions all reported unavailable.