### PR TITLE
Pass GitHub token to feedback collector

### DIFF
--- a/.github/workflows/feedback-collect.yml
+++ b/.github/workflows/feedback-collect.yml
@@ -28,6 +28,8 @@ jobs:
       contents: read
       issues: read
       discussions: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
Set the explicit GH_TOKEN environment variable for the feedback collection job. The collector invokes gh api; local reproduction succeeds with this variable, while Actions previously left all three sources unavailable despite correct permissions.