### PR TITLE
Add paste-hygiene explainer pages for search traffic (autonomous run)

### DIFF
--- a/demo/articles/two-humanizer-ru/index.html
+++ b/demo/articles/two-humanizer-ru/index.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Два humanizer-ru: я отозвал свою лучшую метрику и зову тёзку на бенчмарк</title>
+<meta name="description" content="На GitHub два проекта с именем humanizer-ru. Мой создан 21.01.2026, соседний 03.04.2026. На 11.09.2026 у соседа 333 звезды, у меня 123: в 2,7 раза больше, набрано за два с половиной месяца.">
+<link rel="canonical" href="https://vladimir-human.github.io/humanizer-ru/articles/two-humanizer-ru/">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Два humanizer-ru: я отозвал свою лучшую метрику и зову тёзку на бенчмарк">
+<meta property="og:description" content="На GitHub два проекта с именем humanizer-ru. Мой создан 21.01.2026, соседний 03.04.2026. На 11.09.2026 у соседа 333 звезды, у меня 123: в 2,7 раза больше, набрано за два с половиной месяца.">
+<meta property="og:url" content="https://vladimir-human.github.io/humanizer-ru/articles/two-humanizer-ru/">
+<meta property="og:image" content="https://vladimir-human.github.io/humanizer-ru/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:site_name" content="humanizer-ru">
+<meta property="og:locale" content="ru_RU">
+<meta property="article:published_time" content="2026-09-11">
+<link rel="icon" href="../../favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="../../brand.css">
+<style>
+  main { max-width: 46rem; margin: 0 auto; padding: 20px; }
+  nav.site { padding: 10px 20px; border-bottom: 1px solid var(--line); font-size: 14px; }
+  nav.site a { margin-right: 14px; }
+  pre { background: var(--panel); border: 1px solid var(--line); border-radius: 6px; padding: 10px; overflow: auto; font-family: var(--font-mono); font-size: 13px; white-space: pre-wrap; word-break: break-word; }
+  code { font-family: var(--font-mono); font-size: 0.92em; word-break: break-word; }
+  footer.site { border-top: 1px solid var(--line); padding: 12px 20px; color: var(--muted); font-size: 13px; }
+  .note { color: var(--muted); font-size: 13px; }
+  .byline { color: var(--muted); margin-top: 2.2em; border-top: 1px solid var(--line); padding-top: 10px; }
+  h2 { margin-top: 1.7em; }
+  li, p { overflow-wrap: anywhere; }
+</style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Два humanizer-ru: я отозвал свою лучшую метрику и зову тёзку на бенчмарк",
+  "description": "На GitHub два проекта с именем humanizer-ru. Мой создан 21.01.2026, соседний 03.04.2026. На 11.09.2026 у соседа 333 звезды, у меня 123: в 2,7 раза больше, набрано за два с половиной месяца.",
+  "inLanguage": "ru",
+  "datePublished": "2026-09-11",
+  "author": {
+    "@type": "Person",
+    "name": "Vladimir-Human",
+    "url": "https://github.com/Vladimir-Human"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "humanizer-ru",
+    "url": "https://github.com/Vladimir-Human/humanizer-ru"
+  },
+  "mainEntityOfPage": "https://vladimir-human.github.io/humanizer-ru/articles/two-humanizer-ru/",
+  "image": "https://vladimir-human.github.io/humanizer-ru/og-image.png"
+}
+</script>
+</head>
+<body>
+<nav class="site">
+  <a href="../../index.html">Демо-сканер</a>
+  <a href="../../oaicite/">Метки oaicite</a>
+  <a href="../../invisible/">Невидимые символы</a>
+  <a href="../../utm/">utm-метки</a>
+  <a href="https://github.com/Vladimir-Human/humanizer-ru">Репозиторий</a>
+</nav>
+<main>
+<article>
+<h1>Два humanizer-ru: я отозвал свою лучшую метрику и зову тёзку на бенчмарк</h1>
+
+<h2>Два проекта с одним именем</h2>
+
+<p>На GitHub два проекта с именем humanizer-ru. Мой создан 21.01.2026, соседний 03.04.2026. На 11.09.2026 у соседа 333 звезды, у меня 123: в 2,7 раза больше, набрано за два с половиной месяца. Проверка: <code>gh repo view &lt;владелец&gt;/humanizer-ru --json stargazerCount</code> и <code>gh api repos/&lt;владелец&gt;/humanizer-ru --jq .created_at</code>.</p>
+
+<p>Разница не только в звёздах. Описание соседа обещает «64 признака нейросети, 21 жёсткий бан, сканер в комплекте» (дословно: <code>gh api repos/ilyautov/humanizer-ru --jq .description</code>, снято 11.09.2026). В моём проекте такие обещания запрещены списком: identity.v1.json перечисляет формулировки, которых проект не имеет права произносить. «Обход детекторов как гарантия», «доказывает, что текст написан человеком», «не искажая смысла» и ещё пять. Гейт check_identity.py сверяет их дрейф по всем носителям (коммит c54c46a).</p>
+
+<p>Почему я отказался от слов, которые продают лучше? Измерил собственное обещание, и лучшее число пришлось отозвать самому.</p>
+
+<h2>Число, которое я опубликовал, а потом снял</h2>
+
+<p>25.08.2026 я опубликовал дельту детектируемости: на 12 парах средний скор судейской оценки падал после переписывания с 0.846 до 0.438. Дельта −0.408, знак-тест p=0.006, ниже в 11 парах из 12. Воспроизведение: <code>python3 eval/reproduce.py</code>, данные в eval/detect-results/2026-08-25-detect-axis-12-glm53.json.</p>
+
+<p>Я поставил три контроля, и один убил результат. Реплика на других судейских линиях падение повторила, контроль метки держался. Сломал контроль формата: одна уборка оформления перед переписыванием (шапка обвязки, переносы, разметка, дефисы вместо тире) воспроизводит падение скора почти целиком. Разложение по трём семьям судей: интервал без нуля у канала «формат» в трёх из трёх, у канала «смысл сверх формата» ни в одном (ERRATA.md от 01.09.2026, разбор в research/AXIS-RUBRIC-RETRACTION-2026-09-01.md). Значит −0.408 измеряла не живость текста, а снятие оформления. Интерпретацию я отозвал, число оставил в данных как замер своей величины. Нюанс про судей: одна линия панели повторяла семью, давшую исходное число; независимых линий три.</p>
+
+<p>Второй провал: положительный контроль читательской метрики 03.09.2026, сырой машинный текст против согласованного человеческого, та же панель и слепая подача, предрегистрация заморожена хешем. Вердикт FAIL: панель не отличила сырой машинный текст от человеческого, две семьи судей из трёх дали инверсию, выбирали машинный текст как «более человеческий». Отчёт: research/DI-CONTROL-2026-09.md. Читательское измерение слепо на контрасте, которым я собирался показывать качество переписывания: выводы по этой оси неинтерпретируемы, переписывание переехало в класс C, по явной просьбе и без заявлений о качестве. У таких замеров теперь гриф «судьи LLM, до человеческого контроля». Числа записи контроля приостановлены эрратой 06.09.2026: воспроизведение упирается в данные приватного прогона, цитировать их публично до раскрытия было бы нечестно (ERRATA.md). Исторический отчёт открыт.</p>
+
+<h2>Что проверки пережили</h2>
+
+<p>Уцелел детерминированный слой: он не судит текст, а ищет следы вставки; его числа воспроизводятся из публичных данных.</p>
+
+<p>Ложные срабатывания маркеров на 12314 текстах-неносителях лёгкого домена (04.09.2026, один проход по замороженной предрегистрации): класс A дал 0, класс B 8, это 0.00065 с Wilson 95% интервалом [0.0003; 0.0013]. Все восемь объяснены: BOM вики-шаблонов, нулевая ширина, bidi-маркеры, переносы из PDF. Воспроизведение <code>python tools/fp_corpus_measure.py</code>, отчёт research/FP-CORPUS-2026.md.</p>
+
+<p>Человеческий контроль: парный прогон 03.09.2026, 0 срабатываний на 26 человеческих текстах, Wilson [0%; 12.9%]. Воспроизведение: <code>python3 eval/run_eval.py</code> + <code>python3 scripts/check_confidence.py --check</code>, корпус eval/manifest.v1.json с хешами. Ноль публикуется как ноль и ходит с интервалом: 0 из 26 это наблюдение, не обещание.</p>
+
+<p>Мягкий статистический слой как детектор мёртв, говорю это вслух. На реалистичном корпусе (90 машинных против 440 человеческих) нет рабочей точки «recall выше нуля при нуле ложных обвинений»: при T=1/K=1 recall 0.211 [0.140; 0.306] при доле ложных обвинений 0.491 [0.445; 0.538] (ERRATA.md от 01.09.2026). Прежнее заявление «62.5% recall при FP=0» отозвано там же. AUC мягкого счёта: 0.6068 и 0.6487 по поколениям генераторов, на тяжёлом домене 0.1626, инверсия (research/F8-UMBRELLA-2026.md, 04.09.2026, <code>tools/f8_corpus_build.py</code> + <code>tools/f8_measure.py</code>). У мягких признаков осталась одна честная роль: калибровать объём правки, а не выносить вердикты.</p>
+
+<h2>Зову тёзку на публичный бенчмарк</h2>
+
+<p>03.09.2026 я открыл issue #57 в соседнем репозитории: открытый протокол после-измерения и репликационный комплект без условий, каждый прогоняет его на своём проекте. 07.09.2026 автор ответил, цитата: «опубликовать тестовые данные. Ну типа, публичный тест, публичные данные. Сделать бенч для хуманайзеров. Буду рад поучаствовать». 10.09.2026 автор закрыл issue как отработанный. Ветка: <a href="https://github.com/ilyautov/humanizer-ru/issues/57">https://github.com/ilyautov/humanizer-ru/issues/57</a>, воспроизведение: <code>gh api repos/ilyautov/humanizer-ru/issues/57</code> и /comments. Манифест метода: research/REWRITE-MEASUREMENT-2026-09.md.</p>
+
+<p>Предложение принимаю. Условия уже работают у меня:</p>
+
+<ol>
+  <li>Публичные данные: корпуса с хешами, прогон одной командой.</li>
+  <li>Предрегистрация до прогона, правило свёртки результата заморожено хешем.</li>
+  <li>Каждое число с датой и командой; недоступное публикуется как недоступное, с причиной (METRICS.md).</li>
+  <li>Никаких таблиц с чужими именами: сравнение только парным прогоном одной даты на общем корпусе (LEADERBOARD.md).</li>
+  <li>Никаких вердиктов об авторстве: детекторные метрики относительные.</li>
+</ol>
+
+<h2>Что инструмент делает на самом деле</h2>
+
+<p>Ядро детерминированное: 40 regex-маркеров, 31 класса A и 9 класса B (count/class_a_count/class_b_count в markers.v1.json, коммит c54c46a). Класс A: жёсткие артефакты копипасты, <code>:contentReference[oaicite:N]</code>, <code>?utm_source=chatgpt.com</code>, <code>grok_card://</code>, метки шагов агента, адреса песочниц. Класс B: контекстные индикаторы, невидимые символы, заглушки шаблонов, символы приватной области. У 38 маркеров из 40 есть запись доказательства с URL и дословным образцом (research/fixtures/marker-sources.json).</p>
+
+<p>Невидимые символы разделены на 23 диапазона по риску: 9 safe снимаются (zero-width space, BOM, мягкий перенос), 11 ambiguous только с явным согласием, они легитимны в эмодзи и смешанных направлениях письма, 3 dangerous не снимаются никогда: U+2028 и U+2029 держат структуру строк и абзацев (markers.v1.json, invisible_classes). Режима «удалить всё невидимое одним движением» нет по построению, это тоже пункт запрещённых обещаний.</p>
+
+<p>Маркер класса A означает факт вставки и статус «источник требует проверки»; вердикта об авторстве нет ни по A, ни по B: совпадения класса B мало даже для рекомендации проверить. Это Главное правило скилла.</p>
+
+<p>Носители: CLI из восьми команд (<code>pip install humanizer-ru</code>, 3.35.2 от 08.09.2026, <a href="https://pypi.org/pypi/humanizer-ru/json">https://pypi.org/pypi/humanizer-ru/json</a>, stdlib), MCP-сервер из семи инструментов, active в официальном реестре (11.09.2026, <a href="https://registry.modelcontextprotocol.io/v0.1/servers/io.github.Vladimir-Human%2Fhumanizer-ru/versions/latest">https://registry.modelcontextprotocol.io/v0.1/servers/io.github.Vladimir-Human%2Fhumanizer-ru/versions/latest</a>), GitHub Action с гейтом вставки, браузерное демо, где текст не покидает браузер (<a href="https://vladimir-human.github.io/humanizer-ru/">https://vladimir-human.github.io/humanizer-ru/</a>).</p>
+
+<h2>Честные границы</h2>
+
+<p>Перефраз и гладкий машинный текст без артефактов слой не ловит: статистика как детектор не работает (показано выше). Короткий текст не ловится: сигналов меньше, чем слов. Водяные знаки без ключа невидимы по построению. Смешанное авторство инструмент не разбирает, английские детекторы не импортирует. Тяжёлый домен остаётся зоной риска: ложных срабатываний на порядок чаще (оба замера 04.09.2026, числа выше). Полные границы: docs/THREAT-MODEL.md.</p>
+
+<p>Собственная чистилка побеждает собственный детектор: после <code>humanizer-polish --remove</code> recall внедрённых маркеров падает с 1.0 до 0.1579, порог 0.5 не выполнен (research/ADVERSARIAL-ROBUSTNESS-V2-2026.md, 04.09.2026, воспроизведение <code>tools/mutants_build.py</code>, <code>tools/f3v2_measure.py</code>, <code>tools/f3v2_rewrite_measure.py</code>). Слепая перезапись теряет факты: доля пар с потерей 0.5699 [0.4685; 0.6658], с добавлением нового 0.3441 (research/FACT-LOSS-2026.md, 04.09.2026, <code>python tools/factloss_measure.py</code>). Поэтому переписывание идёт со сверкой <code>humanizer-facts diff</code>, а обещание «смысл сохранится» в запрещённом списке.</p>
+
+<p>Главная граница: проект почти не видят. Предрегистрированный замер находимости 03.09.2026 дал 2 находки из 5, порог пройден впритык (research/findability-prereg-2026-09-03.md, следующий замер не раньше 1 октября). Из 490 посетителей репо за 14 дней 229 пришли из Google (<code>gh api repos/Vladimir-Human/humanizer-ru/traffic/popular/referrers</code>, owner-only, окно 28.08–10.09.2026). Авторских публикаций нет: на 11.09.2026 я не нашёл ни одной от имени проекта; запросы <code>"Vladimir-Human" habr</code>, <code>"Vladimir-Human" vc.ru</code>, <code>humanizer-ru статья</code> возвращают только репозиторий и автокаталоги. Установки skills.sh растут: 603 на 06.09.2026 (research/DISTRIBUTION-JOURNAL.md), 633 на 11.09.2026 (<a href="https://www.skills.sh/vladimir-human/humanizer-ru/humanizer-ru">https://www.skills.sh/vladimir-human/humanizer-ru/humanizer-ru</a>). PyPI: 2605 за неделю на 11.09.2026 (<a href="https://pypistats.org/api/packages/humanizer-ru/recent">https://pypistats.org/api/packages/humanizer-ru/recent</a>), внутри собственный CI, чистой аудитории счётчик не даёт (METRICS.md). Если эта статья выйдет, она будет первой авторской публикацией проекта.</p>
+
+<h2>Вместо вывода</h2>
+
+<p>Я не могу написать в описании репозитория «64 признака и 21 бан»: identity.v1.json запрещает, гейт сверяет все носители. Что могу показать: реестр из 28 чисел, где 2 proven, 23 limited и 3 withdrawn на 08.09.2026 (eval/facts/facts.v1.json, пересчёт статусов: <code>jq -r '.entries[].status' eval/facts/facts.v1.json | sort | uniq -c</code>), эррату с шестью датированными записями (заголовки ERRATA.md на 11.09.2026), лидерборд с парным прогоном одной даты, приглашение к бенчмарку. Инструмент, который отзывает собственное лучшее число, остаётся должен читателю одно: всё остальное пересчитывается.</p>
+
+<p class="byline">Автор: Vladimir-Human, проект humanizer-ru (<a href="https://github.com/Vladimir-Human/humanizer-ru">https://github.com/Vladimir-Human/humanizer-ru</a>).</p>
+</article>
+</main>
+<footer class="site">
+  humanizer-ru — проверяемая гигиена вставки из чата для русского текста.
+  <a href="../../index.html">Демо</a> ·
+  <a href="https://github.com/Vladimir-Human/humanizer-ru">репозиторий</a> ·
+  <a href="https://pypi.org/project/humanizer-ru/">PyPI</a>.
+  Разборы: <a href="../../oaicite/">:contentReference[oaicite:N]</a> ·
+  <a href="../../invisible/">невидимые символы</a> ·
+  <a href="../../utm/">utm_source=chatgpt.com</a>.
+  Аналитики и трекеров на странице нет: проект ничего не собирает.
+</footer>
+</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,6 +5,7 @@
 <link rel="icon" href="favicon.svg" type="image/svg+xml">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="Гигиена вставки из чата для русского текста: детерминированно, офлайн, флаги с причиной и советом.">
+<link rel="canonical" href="https://vladimir-human.github.io/humanizer-ru/">
 <meta property="og:title" content="Проверяемая гигиена вставки из чата для русского текста">
 <meta property="og:description" content="Гигиена вставки из чата для русского текста: детерминированно, офлайн, флаги с причиной и советом.">
 <meta property="og:type" content="website">
@@ -328,6 +329,20 @@
   run();
 })();
 </script>
+<section id="explainers" style="max-width:1100px;margin:0 auto;padding:0 20px 12px;">
+  <h2>Разборы следов вставки</h2>
+  <ul style="overflow-wrap:anywhere;">
+    <li><a href="oaicite/">:contentReference[oaicite:N]{index=N} — что это и как убрать</a></li>
+    <li><a href="invisible/">Невидимые символы после ChatGPT и пробел U+202F</a></li>
+    <li><a href="utm/">utm_source=chatgpt.com в тексте — что это и как убрать</a></li>
+  </ul>
+</section>
+<section id="articles" style="max-width:1100px;margin:0 auto;padding:0 20px 12px;">
+  <h2>Статьи</h2>
+  <ul style="overflow-wrap:anywhere;">
+    <li><a href="articles/two-humanizer-ru/">Два humanizer-ru: я отозвал свою лучшую метрику и зову тёзку на бенчмарк</a></li>
+  </ul>
+</section>
 <details id="dev" style="max-width:1100px;margin:0 auto;padding:8px 20px;">
   <summary>Для разработчиков</summary>
   <p class="rule">40 выражений загружаются из статического markers.js

--- a/demo/invisible/index.html
+++ b/demo/invisible/index.html
@@ -1,0 +1,229 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Невидимые символы после ChatGPT: как найти и удалить</title>
+<meta name="description" content="Нулевые пробелы, PUA-символы цитат ChatGPT, Unicode-теги и узкий неразрывный пробел U+202F: откуда они берутся в тексте, что снимается безопасно, а что не снимается никогда.">
+<link rel="canonical" href="https://vladimir-human.github.io/humanizer-ru/invisible/">
+<meta property="og:type" content="article">
+<meta property="og:title" content="Невидимые символы после ChatGPT: как найти и удалить">
+<meta property="og:description" content="Нулевые пробелы, PUA-символы цитат ChatGPT, Unicode-теги и узкий неразрывный пробел U+202F: откуда они берутся в тексте, что снимается безопасно, а что не снимается никогда.">
+<meta property="og:url" content="https://vladimir-human.github.io/humanizer-ru/invisible/">
+<meta property="og:image" content="https://vladimir-human.github.io/humanizer-ru/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:site_name" content="humanizer-ru">
+<meta property="og:locale" content="ru_RU">
+<link rel="icon" href="../favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="../brand.css">
+<style>
+  main { max-width: 46rem; margin: 0 auto; padding: 20px; }
+  nav.site { padding: 10px 20px; border-bottom: 1px solid var(--line); font-size: 14px; }
+  nav.site a { margin-right: 14px; }
+  pre { background: var(--panel); border: 1px solid var(--line); border-radius: 6px; padding: 10px; overflow: auto; font-family: var(--font-mono); font-size: 13px; white-space: pre-wrap; word-break: break-word; }
+  code { font-family: var(--font-mono); font-size: 0.92em; word-break: break-word; }
+  table { border-collapse: collapse; width: 100%; font-size: 14px; }
+  th, td { border: 1px solid var(--line); padding: 6px 8px; text-align: left; vertical-align: top; }
+  footer.site { border-top: 1px solid var(--line); padding: 12px 20px; color: var(--muted); font-size: 13px; }
+  .note { color: var(--muted); font-size: 13px; }
+  .cta { display: inline-block; padding: 8px 14px; border-radius: 6px; background: var(--accent1); color: #fff; text-decoration: none; }
+  h2 { margin-top: 1.7em; }
+  li { overflow-wrap: anywhere; }
+  .src { font-size: 13px; color: var(--muted); }
+</style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Как удалить невидимые символы из текста после ChatGPT?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Проверьте текст в браузерном демо humanizer-ru или в терминале: pip install humanizer-ru, затем humanizer-markers --scan файл.txt. Снимает safe-символы команда humanizer-markers --remove, полный сценарий с проверкой до и после — humanizer-clean файл.txt."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Нулевой пробел в тексте доказывает, что его написала нейросеть?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Нет. Нулевые пробелы заносятся и другим копированием: сайты, CMS, рассылки. Находка указывает на путь текста и требует проверки происхождения, вердикта об авторстве нет."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "U+202F — это водяной знак ИИ? Можно ли его удалить?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "U+202F — узкий неразрывный пробел, легитимный типографский символ, а не сертифицированный знак происхождения. В таблице humanizer-ru он относится к классу ambiguous: замена на обычный пробел возможна только в явном режиме --include-ambiguous, инструмент показывает изменения и предупреждает о риске."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Правда ли, что инструмент удаляет все невидимые символы?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Нет. Опасные структурные символы (разделители строк и абзацев, межстрочные аннотации) показываются в отчёте и не снимаются никогда; невидимый символ вне таблицы считается опасным. Массового режима «удалить всё невидимое» не существует по построению."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Гарантирует ли снятие невидимых символов обход детекторов ИИ?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Нет. Проект не обещает обход детекторов как гарантию и не измеряет его. Снятие символов — гигиена вставки для контента, которым вы владеете."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<nav class="site">
+  <a href="../index.html">Демо-сканер</a>
+  <a href="../oaicite/">Метки oaicite</a>
+  <a href="../utm/">utm-метки</a>
+  <a href="https://github.com/Vladimir-Human/humanizer-ru">Репозиторий</a>
+</nav>
+<main>
+<h1>Невидимые символы в тексте после ChatGPT: как найти и удалить</h1>
+
+<p>Невидимые символы — это кодовые точки, которых не показывает редактор, но которые хранит файл. После копирования из чата в тексте остаются обвязки цитат. Реже встречаются скрытые переносы и специальные пробелы. На глаз их не найти: нужна проверка посимвольно.</p>
+
+<p><a class="cta" href="../index.html">Проверить текст в браузерном демо</a> <span class="note">текст не покидает браузер</span></p>
+
+<h2>Что обычно остаётся после чата</h2>
+
+<p>Следующие диапазоны таблица снятия humanizer-ru относит к классу safe: это обвязка копипасты, она снимается автоматически.</p>
+
+<ul>
+  <li><code>U+200B</code> — нулевой пробел (zero-width space);</li>
+  <li><code>U+2060</code> — соединитель слов (word joiner);</li>
+  <li><code>U+FEFF</code> — маркер порядка байтов (BOM), встречается и после правок кодировок;</li>
+  <li><code>U+00AD</code> — мягкий перенос: ломает поиск по документу и сравнение строк;</li>
+  <li><code>U+E200–U+E204</code> и <code>U+EA01–U+EA02</code> — символы приватной области, которыми интерфейс ChatGPT обрамляет цитаты и скрытые блоки;</li>
+  <li><code>U+E0000–U+E007F</code> — Unicode-теги вне эмодзи-флагов.</li>
+</ul>
+
+<p>Живые примеры из реестра доказательств humanizer-ru (каждая запись привязана к снимку ревизии с датой доступа):</p>
+
+<ul>
+  <li>Август 2024 года, статья Amu Television в английской Википедии: в скопированном тексте двадцать три нулевых пробела <code>U+200B</code>. Проверено 2026-08-06.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=Amu_Television&amp;oldid=1241301672">en.wikipedia.org, ревизия 1241301672</a></span></li>
+  <li>Февраль 2025 года, статья List of English-medium schools in Bangladesh: двенадцать невидимых символов <code>U+E200–U+E202</code> вокруг меток цитирования ChatGPT. Проверено 2026-08-06.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=List_of_English-medium_schools_in_Bangladesh&amp;oldid=1274664396">en.wikipedia.org, ревизия 1274664396</a></span></li>
+  <li>Июль 2025 года, снимок страницы Wikipedia:Signs of AI writing: короткая форма сносок ChatGPT — цифра между невидимыми символами <code>U+EA01</code> и <code>U+EA02</code>. Проверено 2026-07-14.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=Wikipedia:Signs_of_AI_writing&amp;oldid=1363998845">en.wikipedia.org, ревизия 1363998845</a></span></li>
+</ul>
+
+<p class="note">Оговорка честности: нулевые пробелы и невидимая разметка — находки класса B. Их заносят и другие источники: сайты, CMS, почтовые рассылки. Модель в примерах выше не атрибутирована, вердиктом об авторстве такая находка не является.</p>
+
+<h2>Unicode-теги и стеганографические «водяные знаки»</h2>
+
+<p>Блок тегов <code>U+E0000–U+E007F</code> используют и исследовательские схемы скрытой маркировки. В работе SteganoPrompt (arXiv:2605.16336, AIES 2026) печатная нагрузка кодируется символами этого блока по правилу <code>chr(0xE0000 + ord(c))</code>: закодированный текст визуально неотличим от исходного и переживает копирование между редакторами. Проверено 2026-08-25.</p>
+
+<p class="src"><a href="https://arxiv.org/abs/2605.16336v2">arxiv.org/abs/2605.16336v2</a></p>
+
+<p>Теги внутри эмодзи-флагов (Англия, Шотландия, Уэльс) легитимны и не снимаются ни в каком режиме: проверка отличает флаг от одиночных тегов.</p>
+
+<h2>U+202F: не «водяной знак», а узкий неразрывный пробел</h2>
+
+<p>Запрос «удалить водяные знаки U+202F» встречается часто, поэтому ответим прямо. <code>U+202F</code> (narrow no-break space) — типографский символ из набора Юникода. У него нет владельца и нет сертификата происхождения: его ставят и системы вёрстки, и чат-интерфейсы, и человек с клавиатурой. Называть его водяным знаком нельзя.</p>
+
+<p>Публичный разбор классов меток watermarks-remover (MIT) описывает снимаемый слой: мягкий перенос <code>0x00AD</code>, наборные пробелы <code>0x2000–0x200A</code>, вариационные селекторы <code>0xFE00–0xFE0F</code>. Русская редакция таблицы исключает неразрывный пробел <code>U+00A0</code> и узкий неразрывный пробел <code>U+202F</code> — это норма набора. Проверено 2026-08-26.</p>
+
+<p class="src"><a href="https://github.com/guillaumemeyer/watermarks-remover/blob/f10efaa7efc75591b4744cc1d885874a79f5f7ee/skills/remove-ai-marks/scripts/text_unicode.py">github.com, watermarks-remover, снимок f10efaa7</a></p>
+
+<p>В таблице снятия humanizer-ru <code>U+202F</code> относится к классу ambiguous: замена на обычный пробел возможна только в явном режиме <code>--include-ambiguous</code>, инструмент показывает изменения и предупреждает о риске.</p>
+
+<h2>Что снимается, а что нет</h2>
+
+<table>
+  <tr><th>Класс</th><th>Примеры</th><th>Действие</th></tr>
+  <tr>
+    <td>safe</td>
+    <td>нулевой пробел, мягкий перенос, BOM, PUA-обвязка цитат ChatGPT, Unicode-теги вне флагов</td>
+    <td>снимаются автоматически; результат проверяем повторным прогоном</td>
+  </tr>
+  <tr>
+    <td>ambiguous</td>
+    <td>ZWJ/ZWNJ, bidi-метки, вариационные селекторы, спецпробелы (NBSP, U+2009, U+202F)</td>
+    <td>только в явном режиме <code>--include-ambiguous</code>; спецпробелы заменяются обычным пробелом, а не удаляются</td>
+  </tr>
+  <tr>
+    <td>dangerous</td>
+    <td>разделитель строк U+2028, разделитель абзацев U+2029, межстрочные аннотации U+FFF9–U+FFFB</td>
+    <td>показываются в отчёте и не снимаются никогда; символ вне таблицы считается dangerous</td>
+  </tr>
+</table>
+
+<p>Массового режима «удалить всё невидимое» не существует по построению: снятие структурных символов склеивает строки и теряет чтение.</p>
+
+<h2>Как проверить и снять</h2>
+
+<p>Без установки: <a href="../index.html">демо в браузере</a> подсвечивает находки, в том числе невидимые, и объясняет каждую. Расчёт идёт локально.</p>
+
+<p>В терминале:</p>
+
+<pre><code>pip install humanizer-ru
+humanizer-markers --scan файл.txt
+humanizer-markers --remove файл.txt
+humanizer-clean файл.txt</code></pre>
+
+<ul>
+  <li><code>--scan</code> — отчёт: какие символы найдены, в каких строках, какого класса;</li>
+  <li><code>--remove</code> — снимает safe-диапазоны, ambiguous только с флагом <code>--include-ambiguous</code>, dangerous показывает и не трогает;</li>
+  <li><code>humanizer-clean</code> — полный сценарий: проверка до, снятие поддерживаемых артефактов, проверка после; неподдерживаемые находки остаются явным остатком;</li>
+  <li>в агентной среде тот же набор доступен через MCP, конфигурация одной строкой:
+  <pre><code>{"mcpServers":{"humanizer-ru":{"command":"uvx","args":["--from","humanizer-ru","humanizer-mcp"]}}}</code></pre></li>
+</ul>
+
+<h2>Честные границы</h2>
+
+<ul>
+  <li>Находка невидимых символов — факт о тексте, а не вердикт об авторстве. Кроме служебных меток интерфейсов такие символы приносит обычное копирование.</li>
+  <li>Снятие не обещает «обход детекторов». Проект таких гарантий не даёт.</li>
+  <li>Снятие выполняется для контента, которым вы владеете; ответственность за использование результата остаётся на вас.</li>
+  <li>Текст не покидает вашу машину: демо считает в браузере; команды пакета и MCP-сервер работают локально. Телеметрии нет.</li>
+</ul>
+
+<h2>Вопросы и ответы</h2>
+
+<h3>Как удалить невидимые символы из текста после ChatGPT?</h3>
+<p>Проверьте текст в браузерном демо humanizer-ru или в терминале: <code>pip install humanizer-ru</code>, затем <code>humanizer-markers --scan файл.txt</code>. Снимает safe-символы команда <code>humanizer-markers --remove</code>, полный сценарий с проверкой до и после — <code>humanizer-clean файл.txt</code>.</p>
+
+<h3>Нулевой пробел в тексте доказывает, что его написала нейросеть?</h3>
+<p>Нет. Нулевые пробелы заносятся и другим копированием: сайты, CMS, рассылки. Находка указывает на путь текста и требует проверки происхождения, вердикта об авторстве нет.</p>
+
+<h3>U+202F — это водяной знак ИИ? Можно ли его удалить?</h3>
+<p><code>U+202F</code> — узкий неразрывный пробел, легитимный типографский символ, а не сертифицированный знак происхождения. В таблице humanizer-ru он относится к классу ambiguous: замена на обычный пробел возможна только в явном режиме <code>--include-ambiguous</code>, инструмент показывает изменения и предупреждает о риске.</p>
+
+<h3>Правда ли, что инструмент удаляет все невидимые символы?</h3>
+<p>Нет. Опасные структурные символы (разделители строк и абзацев, межстрочные аннотации) показываются в отчёте и не снимаются никогда; невидимый символ вне таблицы считается опасным. Массового режима «удалить всё невидимое» не существует по построению.</p>
+
+<h3>Гарантирует ли снятие невидимых символов обход детекторов ИИ?</h3>
+<p>Нет. Проект не обещает обход детекторов как гарантию и не измеряет его. Снятие символов — гигиена вставки для контента, которым вы владеете.</p>
+
+<h2>Источники</h2>
+<ul>
+  <li class="src">Ревизия статьи Amu Television, английская Википедия (дата доступа 2026-08-06): <a href="https://en.wikipedia.org/w/index.php?title=Amu_Television&amp;oldid=1241301672">https://en.wikipedia.org/w/index.php?title=Amu_Television&amp;oldid=1241301672</a></li>
+  <li class="src">Ревизия статьи List of English-medium schools in Bangladesh (дата доступа 2026-08-06): <a href="https://en.wikipedia.org/w/index.php?title=List_of_English-medium_schools_in_Bangladesh&amp;oldid=1274664396">https://en.wikipedia.org/w/index.php?title=List_of_English-medium_schools_in_Bangladesh&amp;oldid=1274664396</a></li>
+  <li class="src">Снимок страницы Wikipedia:Signs of AI writing (дата доступа 2026-07-14): <a href="https://en.wikipedia.org/w/index.php?title=Wikipedia:Signs_of_AI_writing&amp;oldid=1363998845">https://en.wikipedia.org/w/index.php?title=Wikipedia:Signs_of_AI_writing&amp;oldid=1363998845</a></li>
+  <li class="src">Aiersilan, Yousefi, Pless. On Seeding Watermarks to Detect Verbatim LLM Copy-Paste Responses (дата доступа 2026-08-25): <a href="https://arxiv.org/abs/2605.16336v2">https://arxiv.org/abs/2605.16336v2</a></li>
+  <li class="src">Публичный разбор классов невидимых меток watermarks-remover, MIT (дата доступа 2026-08-26): <a href="https://github.com/guillaumemeyer/watermarks-remover/blob/f10efaa7efc75591b4744cc1d885874a79f5f7ee/skills/remove-ai-marks/scripts/text_unicode.py">снимок f10efaa7 в репозитории guillaumemeyer/watermarks-remover</a></li>
+</ul>
+</main>
+<footer class="site">
+  humanizer-ru — проверяемая гигиена вставки из чата для русского текста.
+  <a href="../index.html">Демо</a> ·
+  <a href="https://github.com/Vladimir-Human/humanizer-ru">репозиторий</a> ·
+  <a href="https://pypi.org/project/humanizer-ru/">PyPI</a>.
+  Разборы: <a href="../oaicite/">:contentReference[oaicite:N]</a> ·
+  <a href="../utm/">utm_source=chatgpt.com</a>.
+  Аналитики и трекеров на странице нет: проект ничего не собирает.
+</footer>
+</body>
+</html>

--- a/demo/oaicite/index.html
+++ b/demo/oaicite/index.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>:contentReference[oaicite:N] — что это и как убрать</title>
+<meta name="description" content="Служебная сноска :contentReference[oaicite:N]{index=N} попадает в текст при копировании ответа ChatGPT. Как проверить и снять метку: демо в браузере, команды humanizer-ru, честные границы.">
+<link rel="canonical" href="https://vladimir-human.github.io/humanizer-ru/oaicite/">
+<meta property="og:type" content="article">
+<meta property="og:title" content=":contentReference[oaicite:N] — что это и как убрать">
+<meta property="og:description" content="Служебная сноска :contentReference[oaicite:N]{index=N} попадает в текст при копировании ответа ChatGPT. Как проверить и снять метку: демо в браузере, команды humanizer-ru, честные границы.">
+<meta property="og:url" content="https://vladimir-human.github.io/humanizer-ru/oaicite/">
+<meta property="og:image" content="https://vladimir-human.github.io/humanizer-ru/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:site_name" content="humanizer-ru">
+<meta property="og:locale" content="ru_RU">
+<link rel="icon" href="../favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="../brand.css">
+<style>
+  main { max-width: 46rem; margin: 0 auto; padding: 20px; }
+  nav.site { padding: 10px 20px; border-bottom: 1px solid var(--line); font-size: 14px; }
+  nav.site a { margin-right: 14px; }
+  pre { background: var(--panel); border: 1px solid var(--line); border-radius: 6px; padding: 10px; overflow: auto; font-family: var(--font-mono); font-size: 13px; white-space: pre-wrap; word-break: break-word; }
+  code { font-family: var(--font-mono); font-size: 0.92em; word-break: break-word; }
+  footer.site { border-top: 1px solid var(--line); padding: 12px 20px; color: var(--muted); font-size: 13px; }
+  .note { color: var(--muted); font-size: 13px; }
+  .cta { display: inline-block; padding: 8px 14px; border-radius: 6px; background: var(--accent1); color: #fff; text-decoration: none; }
+  h2 { margin-top: 1.7em; }
+  li { overflow-wrap: anywhere; }
+  .src { font-size: 13px; color: var(--muted); }
+</style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Что означает :contentReference[oaicite:N]{index=N} в тексте?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Это внутренняя метка ссылки в ответе ChatGPT: интерфейс рисует на её месте сноску на источник, а при копировании разметка иногда остаётся в тексте. Вручную такие метки не пишут."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Как убрать метки oaicite из текста?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Вставьте текст в браузерное демо humanizer-ru: сканер подсветит метки и объяснит каждую. В терминале установите пакет (pip install humanizer-ru), проверьте текст командой humanizer-markers --scan и снимите поддерживаемые артефакты командой humanizer-clean."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Если в тексте найдена метка oaicite, это доказывает машинное авторство?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Нет. Метка класса A фиксирует факт вставки: текст копировали из чат-интерфейса. Вердиктов об авторстве инструмент не выносит."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Поможет ли снятие меток обойти детектор ИИ-текста?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Проект не обещает обход детекторов и не измеряет его. Снятие меток — это гигиена вставки: из текста уходит служебная разметка чат-интерфейса, которой в документе быть не должно."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<nav class="site">
+  <a href="../index.html">Демо-сканер</a>
+  <a href="../invisible/">Невидимые символы</a>
+  <a href="../utm/">utm-метки</a>
+  <a href="https://github.com/Vladimir-Human/humanizer-ru">Репозиторий</a>
+</nav>
+<main>
+<h1>:contentReference[oaicite:N]{index=N} — что это и как убрать</h1>
+
+<p>Короткий ответ: это служебная метка ссылки из ответа ChatGPT. Интерфейс рисует на её месте сноску на источник, а при копировании текста наружу иногда уезжает вся разметка. В рукописном тексте таких меток не бывает — их оставляет чат-интерфейс.</p>
+
+<p><a class="cta" href="../index.html">Проверить текст в браузерном демо</a> <span class="note">текст не покидает браузер</span></p>
+
+<h2>Как метка выглядит в тексте</h2>
+
+<p>Так вставку видно в редакторе:</p>
+
+<pre><code>Согласно отчёту :contentReference[oaicite:3]{index=3}, рост заявок.</code></pre>
+
+<p>У одной и той же служебной разметки несколько форм:</p>
+<ul>
+  <li>полная обёртка <code>:contentReference[oaicite:20]{index=20}</code> — номер сноски в квадратных скобках дублируется в фигурных;</li>
+  <li>усечённая форма <code>oaicite:7</code> — внутренний фрагмент той же метки;</li>
+  <li>другой формат сноски <code>oai_citation:0&#8225;wellington.scoop.co.nz</code> — номер и домен источника разделяет символ &#8225; (U+2021);</li>
+  <li>JSON-поле атрибуции <code>{"attribution":{"attributableIndex":"1009-1"}}</code> — встречается в ответах с инструментами;</li>
+  <li>невидимая обвязка: вокруг меток цитирования стоят символы приватной области U+E200–U+E204, которые редактор не отображает. Отдельный <a href="../invisible/">разбор невидимых символов</a> — на соседней странице.</li>
+</ul>
+
+<h2>Откуда берутся эти метки</h2>
+
+<p>Формы задокументированы по живым копиям ответов ChatGPT, которые пользователи перенесли в публичные документы. Каждая запись реестра доказательств humanizer-ru привязана к снимку конкретной ревизии с датой доступа.</p>
+
+<ul>
+  <li>Июнь 2025 года, страница обсуждения статьи Sial (tribe) в английской Википедии: копия ответа ChatGPT с десятью обёртками <code>:contentReference[oaicite:N]{index=N}</code>, номера от 16 до 25. Снимок ревизии проверен 2026-08-06.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=Talk:Sial_(tribe)&amp;oldid=1294765751">en.wikipedia.org, ревизия 1294765751</a></span></li>
+  <li>Июнь 2025 года, страница обсуждения Independent Together: шесть меток <code>oai_citation:N&#8225;</code> и ссылки с параметром <code>utm_source=chatgpt.com</code> в одном тексте. Проверено 2026-08-06.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=Talk:Independent_Together&amp;oldid=1296028135">en.wikipedia.org, ревизия 1296028135</a></span></li>
+  <li>Июнь 2026 года, черновик из примеров страницы Wikipedia:Signs of AI writing: одиннадцать JSON-полей <code>attributableIndex</code>; происхождение копии из ChatGPT подкрепляют utm-метки и <code>oai_citation</code> в том же тексте. Проверено 2026-08-06.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=Wikipedia:Signs_of_AI_writing/Examples/Aleftina_Evdokimova&amp;oldid=1358429496">en.wikipedia.org, ревизия 1358429496</a></span></li>
+  <li>Февраль 2025 года, статья List of English-medium schools in Bangladesh: вокруг меток цитирования остались двенадцать невидимых символов U+E200–U+E202. Проверено 2026-08-06.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=List_of_English-medium_schools_in_Bangladesh&amp;oldid=1274664396">en.wikipedia.org, ревизия 1274664396</a></span></li>
+</ul>
+
+<p class="note">Оговорка честности: атрибуция конкретной версии ChatGPT в этих записях не подтверждена. Метка говорит о пути текста — копирование из чат-интерфейса, — а не о версии модели и не об авторе.</p>
+
+<h2>Как проверить и снять</h2>
+
+<p>Быстрее всего — <a href="../index.html">демо в браузере</a>. Вставьте текст: сканер подсветит метки и объяснит каждую находку. Расчёт идёт на вашей машине, текст никуда не отправляется.</p>
+
+<p>В терминале:</p>
+
+<pre><code>pip install humanizer-ru
+humanizer-markers --scan файл.txt
+humanizer-clean файл.txt</code></pre>
+
+<ul>
+  <li><code>humanizer-markers --scan</code> печатает находки с классом и номером строки; код возврата 1 означает «метки найдены», 0 — чисто, 2 — вход не читается;</li>
+  <li><code>humanizer-clean</code> снимает поддерживаемые артефакты вставки с проверкой до и после: невидимые метки текстового слоя и видимые артефакты класса A вне защищённых областей (код, URL, HTML-атрибуты). Неподдерживаемые находки остаются явным остатком, полная чистота не заявляется;</li>
+  <li>в агентной среде работает тот же набор через MCP, конфигурация одной строкой:
+  <pre><code>{"mcpServers":{"humanizer-ru":{"command":"uvx","args":["--from","humanizer-ru","humanizer-mcp"]}}}</code></pre></li>
+</ul>
+
+<h2>Честные границы</h2>
+
+<ul>
+  <li>Класс A — факт вставки, а не вердикт об авторстве. Метка показывает, что текст прошёл через копирование из чат-интерфейса; кто его написал, инструмент не решает.</li>
+  <li>Снятие меток не обещает «обход детекторов». Проект таких гарантий не даёт и не измеряет их.</li>
+  <li>Совпадение с базой антиплагиата снятие меток не устраняет.</li>
+  <li>Невидимые символы с меткой dangerous (структурные разделители) не снимаются ни в каком режиме.</li>
+  <li>Текст не покидает вашу машину: демо считает в браузере; команды пакета и MCP-сервер работают локально и ничего не отправляют.</li>
+</ul>
+
+<h2>Вопросы и ответы</h2>
+
+<h3>Что означает :contentReference[oaicite:N]{index=N} в тексте?</h3>
+<p>Это внутренняя метка ссылки в ответе ChatGPT: интерфейс рисует на её месте сноску на источник, а при копировании разметка иногда остаётся в тексте. Вручную такие метки не пишут.</p>
+
+<h3>Как убрать метки oaicite из текста?</h3>
+<p>Вставьте текст в браузерное демо humanizer-ru: сканер подсветит метки и объяснит каждую. В терминале установите пакет (<code>pip install humanizer-ru</code>), проверьте текст командой <code>humanizer-markers --scan</code> и снимите поддерживаемые артефакты командой <code>humanizer-clean</code>.</p>
+
+<h3>Если в тексте найдена метка oaicite, это доказывает машинное авторство?</h3>
+<p>Нет. Метка класса A фиксирует факт вставки: текст копировали из чат-интерфейса. Вердиктов об авторстве инструмент не выносит.</p>
+
+<h3>Поможет ли снятие меток обойти детектор ИИ-текста?</h3>
+<p>Проект не обещает обход детекторов и не измеряет его. Снятие меток — это гигиена вставки: из текста уходит служебная разметка чат-интерфейса, которой в документе быть не должно.</p>
+
+<h2>Источники</h2>
+<ul>
+  <li class="src">Ревизия страницы обсуждения Talk:Sial (tribe), английская Википедия (дата доступа 2026-08-06): <a href="https://en.wikipedia.org/w/index.php?title=Talk:Sial_(tribe)&amp;oldid=1294765751">https://en.wikipedia.org/w/index.php?title=Talk:Sial_(tribe)&amp;oldid=1294765751</a></li>
+  <li class="src">Ревизия страницы обсуждения Talk:Independent Together (дата доступа 2026-08-06): <a href="https://en.wikipedia.org/w/index.php?title=Talk:Independent_Together&amp;oldid=1296028135">https://en.wikipedia.org/w/index.php?title=Talk:Independent_Together&amp;oldid=1296028135</a></li>
+  <li class="src">Пример черновика на Wikipedia:Signs of AI writing (дата доступа 2026-08-06): <a href="https://en.wikipedia.org/w/index.php?title=Wikipedia:Signs_of_AI_writing/Examples/Aleftina_Evdokimova&amp;oldid=1358429496">https://en.wikipedia.org/w/index.php?title=Wikipedia:Signs_of_AI_writing/Examples/Aleftina_Evdokimova&amp;oldid=1358429496</a></li>
+  <li class="src">Ревизия статьи List of English-medium schools in Bangladesh (дата доступа 2026-08-06): <a href="https://en.wikipedia.org/w/index.php?title=List_of_English-medium_schools_in_Bangladesh&amp;oldid=1274664396">https://en.wikipedia.org/w/index.php?title=List_of_English-medium_schools_in_Bangladesh&amp;oldid=1274664396</a></li>
+  <li class="src">Снимок страницы Wikipedia:Signs of AI writing, короткая форма меток цитирования (дата доступа 2026-07-14): <a href="https://en.wikipedia.org/w/index.php?title=Wikipedia:Signs_of_AI_writing&amp;oldid=1363998845">https://en.wikipedia.org/w/index.php?title=Wikipedia:Signs_of_AI_writing&amp;oldid=1363998845</a></li>
+</ul>
+</main>
+<footer class="site">
+  humanizer-ru — проверяемая гигиена вставки из чата для русского текста.
+  <a href="../index.html">Демо</a> ·
+  <a href="https://github.com/Vladimir-Human/humanizer-ru">репозиторий</a> ·
+  <a href="https://pypi.org/project/humanizer-ru/">PyPI</a>.
+  Разборы: <a href="../invisible/">невидимые символы</a> ·
+  <a href="../utm/">utm_source=chatgpt.com</a>.
+  Аналитики и трекеров на странице нет: проект ничего не собирает.
+</footer>
+</body>
+</html>

--- a/demo/robots.txt
+++ b/demo/robots.txt
@@ -1,6 +1,8 @@
 User-agent: *
 Allow: /
 
+Sitemap: https://vladimir-human.github.io/humanizer-ru/sitemap.xml
+
 # humanizer-ru: статическое демо и машинные файлы.
 # Машинный вход: /llms.txt и /.well-known/llms.txt
 # Репозиторий: https://github.com/Vladimir-Human/humanizer-ru

--- a/demo/sitemap.xml
+++ b/demo/sitemap.xml
@@ -6,6 +6,26 @@
     <changefreq>weekly</changefreq>
   </url>
   <url>
+    <loc>https://vladimir-human.github.io/humanizer-ru/oaicite/</loc>
+    <lastmod>2026-09-11</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://vladimir-human.github.io/humanizer-ru/invisible/</loc>
+    <lastmod>2026-09-11</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://vladimir-human.github.io/humanizer-ru/utm/</loc>
+    <lastmod>2026-09-11</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://vladimir-human.github.io/humanizer-ru/articles/two-humanizer-ru/</loc>
+    <lastmod>2026-09-11</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
     <loc>https://vladimir-human.github.io/humanizer-ru/llms.txt</loc>
     <lastmod>2026-09-03</lastmod>
     <changefreq>weekly</changefreq>

--- a/demo/sw.js
+++ b/demo/sw.js
@@ -1,5 +1,5 @@
 /* Автогенерация generate_js_rules.py: кэш версионируется хэшем правил, движка, образца и страницы. */
-const CACHE = "humanizer-ru-13d2bad5759a";
+const CACHE = "humanizer-ru-99bc3bf907e1";
 const STATIC = ["./", "./index.html", "./brand.css", "./markers.js",
   "./engine.js", "./sample.js", "./favicon.svg", "./manifest.json"];
 self.addEventListener("install", (e) => {

--- a/demo/utm/index.html
+++ b/demo/utm/index.html
@@ -1,0 +1,181 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>utm_source=chatgpt.com в тексте: что это и как убрать</title>
+<meta name="description" content="Параметр utm_source=chatgpt.com помечает ссылки из ответов ChatGPT: откуда метка берётся в скопированном тексте и как снять её, не ломая ссылку.">
+<link rel="canonical" href="https://vladimir-human.github.io/humanizer-ru/utm/">
+<meta property="og:type" content="article">
+<meta property="og:title" content="utm_source=chatgpt.com в тексте: что это и как убрать">
+<meta property="og:description" content="Параметр utm_source=chatgpt.com помечает ссылки из ответов ChatGPT: откуда метка берётся в скопированном тексте и как снять её, не ломая ссылку.">
+<meta property="og:url" content="https://vladimir-human.github.io/humanizer-ru/utm/">
+<meta property="og:image" content="https://vladimir-human.github.io/humanizer-ru/og-image.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:site_name" content="humanizer-ru">
+<meta property="og:locale" content="ru_RU">
+<link rel="icon" href="../favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="../brand.css">
+<style>
+  main { max-width: 46rem; margin: 0 auto; padding: 20px; }
+  nav.site { padding: 10px 20px; border-bottom: 1px solid var(--line); font-size: 14px; }
+  nav.site a { margin-right: 14px; }
+  pre { background: var(--panel); border: 1px solid var(--line); border-radius: 6px; padding: 10px; overflow: auto; font-family: var(--font-mono); font-size: 13px; white-space: pre-wrap; word-break: break-word; }
+  code { font-family: var(--font-mono); font-size: 0.92em; word-break: break-word; }
+  footer.site { border-top: 1px solid var(--line); padding: 12px 20px; color: var(--muted); font-size: 13px; }
+  .note { color: var(--muted); font-size: 13px; }
+  .cta { display: inline-block; padding: 8px 14px; border-radius: 6px; background: var(--accent1); color: #fff; text-decoration: none; }
+  h2 { margin-top: 1.7em; }
+  li { overflow-wrap: anywhere; }
+  .src { font-size: 13px; color: var(--muted); }
+</style>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Что такое utm_source=chatgpt.com в тексте?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Это параметр ссылки, которым ChatGPT помечает исходящие адреса в ответах: сайт получает отметку источника трафика. Когда ответ копируют в документ или письмо, метка уезжает в текст вместе с адресом."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Как убрать utm-метку из ссылки?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Вручную вырежьте параметр вместе с предшествующим знаком ? или & — адрес страницы сохранится. Автоматически это делает humanizer-clean: команда снимает из URL только параметр, а не всю ссылку. Проверить текст можно в браузерном демо или командой humanizer-markers --scan файл.txt."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Доказывает ли utm_source=chatgpt.com, что текст написан ChatGPT?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Нет. Метка прикреплена к ссылке, а не к тексту: она показывает, что адрес скопирован из интерфейса ChatGPT. Вердиктов об авторстве текста инструмент не выносит."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Перестанет ли ссылка работать без utm-параметра?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Нет. Адрес страницы сохраняется, исчезает только отметка источника для счётчиков аналитики."
+      }
+    }
+  ]
+}
+</script>
+</head>
+<body>
+<nav class="site">
+  <a href="../index.html">Демо-сканер</a>
+  <a href="../oaicite/">Метки oaicite</a>
+  <a href="../invisible/">Невидимые символы</a>
+  <a href="https://github.com/Vladimir-Human/humanizer-ru">Репозиторий</a>
+</nav>
+<main>
+<h1>utm_source=chatgpt.com в тексте: что это и как убрать</h1>
+
+<p>UTM-метки — это параметры в адресе ссылки для счётчиков трафика: они сообщают сайту, откуда пришёл посетитель. ChatGPT добавляет к ссылкам в ответах параметр <code>utm_source=chatgpt.com</code>. Когда ответ копируют в документ или письмо, метка уезжает в текст вместе с адресом.</p>
+
+<p><a class="cta" href="../index.html">Проверить текст в браузерном демо</a> <span class="note">текст не покидает браузер</span></p>
+
+<h2>Как метка выглядит</h2>
+
+<pre><code>https://example.com/article?utm_source=chatgpt.com</code></pre>
+
+<ul>
+  <li><code>?utm_source=chatgpt.com</code> — первый параметр после вопросительного знака;</li>
+  <li><code>&amp;utm_source=chatgpt.com</code> — та же метка среди других параметров;</li>
+  <li><code>?utm_source=openai</code> — общая форма для инструментов OpenAI;</li>
+  <li><code>?utm_source=copilot.com</code> — метка Microsoft Copilot;</li>
+  <li><code>?referrer=grok.com</code> — навигационный параметр xAI.</li>
+</ul>
+
+<h2>Откуда берётся и где замечена</h2>
+
+<p>Записи реестра доказательств humanizer-ru привязаны к снимкам публичных страниц с датами доступа.</p>
+
+<ul>
+  <li>Июнь 2025 года, копия ответа ChatGPT на странице обсуждения Independent Together в английской Википедии: шесть ссылок с <code>utm_source=chatgpt.com</code>; в том же тексте стоят метки <code>oai_citation</code>. Реестр фиксирует форму как метку ссылок, сгенерированных до августа 2025 года. Проверено 2026-08-06.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=Talk:Independent_Together&amp;oldid=1296028135">en.wikipedia.org, ревизия 1296028135</a></span></li>
+  <li>Позже ссылки инструментов OpenAI чаще несут общую форму <code>utm_source=openai</code>: в ревизии статьи Valencia High School от 6 августа 2026 года такая метка стоит в вики-сноске; полнотекстовый поиск по английской Википедии нашёл шесть статей с ней. Проверено 2026-08-06.<br>
+  <span class="src"><a href="https://en.wikipedia.org/w/index.php?title=Valencia_High_School_(Santa_Clarita,_California)&amp;oldid=1368000622">en.wikipedia.org, ревизия 1368000622</a></span></li>
+  <li>Microsoft Copilot ставит свою метку <code>utm_source=copilot.com</code>: коммит студенческой исследовательской работы от 11 июля 2026 года хранит пять ссылок с ней, включая запись в списке литературы. Проверено 2026-08-07.<br>
+  <span class="src"><a href="https://github.com/tectijuana/interfaz/blob/cdc97fc53f6b3030aa14285da456eef7a329d60a/entregas/2026a/research/Arquitecturas%20ARM%20aplicadas%20a%20sistemas%20multimedia/readme.md">github.com, снимок cdc97fc5 в репозитории tectijuana/interfaz</a></span></li>
+  <li>xAI добавляет параметр <code>referrer=grok.com</code> к навигационным ссылкам на официальном сайте (проверено 2026-07-13). Оговорка реестра: параметр встречается и в обычных ссылках, сам по себе он не доказывает генерацию текста.<br>
+  <span class="src"><a href="https://x.ai/grok">x.ai/grok</a></span></li>
+</ul>
+
+<p class="note">Оговорка честности: UTM-метка прикреплена к ссылке, а не к тексту. Она показывает путь адреса — копирование из интерфейса чата, — но не называет автора текста и не утверждает генерацию всего документа.</p>
+
+<h2>Чем метка мешает в тексте</h2>
+
+<p>Ссылка с параметром рабочая: это не поломка. Мешает другое. Параметр передаёт счётчикам сайта источник трафика. Ещё он удлиняет адрес и выдаёт вставку из чат-интерфейса. Для документа, который уходит в публикацию или заказчику, это вопрос гигиены вставки.</p>
+
+<h2>Как проверить и снять</h2>
+
+<p>Без установки: <a href="../index.html">демо в браузере</a> находит utm-метки в ссылках и объясняет каждую. Расчёт идёт локально, текст никуда не отправляется.</p>
+
+<p>В терминале:</p>
+
+<pre><code>pip install humanizer-ru
+humanizer-markers --scan файл.txt
+humanizer-clean файл.txt</code></pre>
+
+<ul>
+  <li><code>humanizer-markers --scan</code> показывает находки с классом и номером строки: utm-метки относятся к классу A;</li>
+  <li><code>humanizer-clean</code> снимает из URL только параметр, а не всю ссылку: адрес страницы сохраняется;</li>
+  <li>вручную: вырежьте параметр <code>utm_*</code> вместе с предшествующим знаком <code>?</code> или <code>&amp;</code>. Если параметр был последним, ссылка останется прежней;</li>
+  <li>в агентной среде тот же набор доступен через MCP, конфигурация одной строкой:
+  <pre><code>{"mcpServers":{"humanizer-ru":{"command":"uvx","args":["--from","humanizer-ru","humanizer-mcp"]}}}</code></pre></li>
+</ul>
+
+<h2>Честные границы</h2>
+
+<ul>
+  <li>Класс A — факт вставки, а не вердикт об авторстве: метка фиксирует происхождение ссылки из интерфейса чата.</li>
+  <li>Снятие метки не обещает «обход детекторов». Проект таких гарантий не даёт и не измеряет их.</li>
+  <li>UTM — легитимный механизм веб-аналитики. В самой метке нет ничего запрещённого; решение снять её относится к аккуратности публикации.</li>
+  <li>Текст не покидает вашу машину: демо считает в браузере; команды пакета и MCP-сервер работают локально. Телеметрии нет.</li>
+</ul>
+
+<h2>Вопросы и ответы</h2>
+
+<h3>Что такое utm_source=chatgpt.com в тексте?</h3>
+<p>Это параметр ссылки, которым ChatGPT помечает исходящие адреса в ответах: сайт получает отметку источника трафика. Когда ответ копируют в документ или письмо, метка уезжает в текст вместе с адресом.</p>
+
+<h3>Как убрать utm-метку из ссылки?</h3>
+<p>Вручную вырежьте параметр вместе с предшествующим знаком <code>?</code> или <code>&amp;</code> — адрес страницы сохранится. Автоматически это делает <code>humanizer-clean</code>: команда снимает из URL только параметр, а не всю ссылку. Проверить текст можно в браузерном демо или командой <code>humanizer-markers --scan файл.txt</code>.</p>
+
+<h3>Доказывает ли utm_source=chatgpt.com, что текст написан ChatGPT?</h3>
+<p>Нет. Метка прикреплена к ссылке, а не к тексту: она показывает, что адрес скопирован из интерфейса ChatGPT. Вердиктов об авторстве текста инструмент не выносит.</p>
+
+<h3>Перестанет ли ссылка работать без utm-параметра?</h3>
+<p>Нет. Адрес страницы сохраняется, исчезает только отметка источника для счётчиков аналитики.</p>
+
+<h2>Источники</h2>
+<ul>
+  <li class="src">Ревизия страницы обсуждения Talk:Independent Together, английская Википедия (дата доступа 2026-08-06): <a href="https://en.wikipedia.org/w/index.php?title=Talk:Independent_Together&amp;oldid=1296028135">https://en.wikipedia.org/w/index.php?title=Talk:Independent_Together&amp;oldid=1296028135</a></li>
+  <li class="src">Ревизия статьи Valencia High School (Santa Clarita, California) (дата доступа 2026-08-06): <a href="https://en.wikipedia.org/w/index.php?title=Valencia_High_School_(Santa_Clarita,_California)&amp;oldid=1368000622">https://en.wikipedia.org/w/index.php?title=Valencia_High_School_(Santa_Clarita,_California)&amp;oldid=1368000622</a></li>
+  <li class="src">Снимок студенческой исследовательской работы в репозитории tectijuana/interfaz, коммит cdc97fc5 от 11 июля 2026 года (дата доступа 2026-08-07): <a href="https://github.com/tectijuana/interfaz/blob/cdc97fc53f6b3030aa14285da456eef7a329d60a/entregas/2026a/research/Arquitecturas%20ARM%20aplicadas%20a%20sistemas%20multimedia/readme.md">github.com, readme.md на cdc97fc5</a></li>
+  <li class="src">Официальный сайт xAI, параметр referrer (дата доступа 2026-07-13): <a href="https://x.ai/grok">https://x.ai/grok</a></li>
+  <li class="src">Общее описание UTM-параметров: <a href="https://en.wikipedia.org/wiki/UTM_parameters">en.wikipedia.org/wiki/UTM_parameters</a></li>
+</ul>
+</main>
+<footer class="site">
+  humanizer-ru — проверяемая гигиена вставки из чата для русского текста.
+  <a href="../index.html">Демо</a> ·
+  <a href="https://github.com/Vladimir-Human/humanizer-ru">репозиторий</a> ·
+  <a href="https://pypi.org/project/humanizer-ru/">PyPI</a>.
+  Разборы: <a href="../oaicite/">:contentReference[oaicite:N]</a> ·
+  <a href="../invisible/">невидимые символы</a>.
+  Аналитики и трекеров на странице нет: проект ничего не собирает.
+</footer>
+</body>
+</html>

--- a/scripts/check_pages_router.py
+++ b/scripts/check_pages_router.py
@@ -8,9 +8,15 @@ llms.txt отдаётся с двух хостов (GitHub и Pages), поэто
 эррата, robots.txt, /.well-known/llms.txt) обязаны быть перечислены в
 шаге копирования workflow Pages и, после деплоя, отдаваться с Pages.
 
+Пояснительные SEO-страницы (SEO_PAGES) живут в самом demo/ и публикуются
+вместе с артефактом Pages; статическая проверка требует их наличия в demo/
+и объявления в demo/sitemap.xml, а --live-pages дополнительно сверяет их
+доступность после деплоя.
+
 Режимы:
     python3 scripts/check_pages_router.py              # ссылки llms.txt (HEAD)
                                                        # + статика workflow
+                                                       # + SEO-страницы
     python3 scripts/check_pages_router.py --live-pages # дополнительно HEAD
                                                        # всех копий на Pages
                                                       # (после деплоя)
@@ -45,7 +51,16 @@ PAGES_PATHS = ["llms.txt", ".well-known/llms.txt", "contract.v1.json",
                "ERRATA.md", "README.md", "README.en.md", "SKILL.md",
                "docs/FRAMEWORK.md", "eval/facts/facts.v1.json", "robots.txt",
                "favicon.svg", "identity.v1.json", "og-image.png",
-               "sitemap.xml", "eval/facts/self-audit.v1.json"]
+               "sitemap.xml", "eval/facts/self-audit.v1.json",
+               "oaicite/index.html", "invisible/index.html",
+               "utm/index.html", "articles/two-humanizer-ru/index.html"]
+# Пояснительные SEO-страницы живут в самом demo/ и публикуются вместе с
+# артефактом Pages: (файл в demo/, канонический URL-суффикс в sitemap.xml).
+SEO_PAGES = [("oaicite/index.html", "oaicite/"),
+             ("invisible/index.html", "invisible/"),
+             ("utm/index.html", "utm/"),
+             ("articles/two-humanizer-ru/index.html",
+              "articles/two-humanizer-ru/")]
 # Строки, которые обязан содержать шаг копирования workflow (статическая
 # проверка до деплоя: на PR ветке Pages ещё старый, сеть по Pages не
 # проверяется, но состав артефакта виден из workflow).
@@ -86,10 +101,34 @@ def http_status(url: str) -> int:
     raise last  # pragma: no cover - цикл всегда возвращает или выбрасывает
 
 
+def seo_errors(demo_root=None, sitemap_text=None) -> list:
+    """SEO-страницы лежат в demo/ и перечислены в sitemap.xml (до деплоя)."""
+    demo_root = demo_root or os.path.join(ROOT, "demo")
+    errors = []
+    for rel, _canon in SEO_PAGES:
+        if not os.path.isfile(os.path.join(demo_root,
+                                           rel.replace("/", os.sep))):
+            errors.append("demo/%s отсутствует — SEO-страница не попадёт "
+                          "в артефакт Pages" % rel)
+    if sitemap_text is None:
+        try:
+            with open(os.path.join(demo_root, "sitemap.xml"),
+                      encoding="utf-8") as fh:
+                sitemap_text = fh.read()
+        except OSError as exc:
+            return errors + ["demo/sitemap.xml не читается: %r" % exc]
+    for _rel, canon in SEO_PAGES:
+        if (PAGES_BASE + canon) not in sitemap_text:
+            errors.append("demo/sitemap.xml: нет URL %s%s — страница "
+                          "не объявлена поисковикам" % (PAGES_BASE, canon))
+    return errors
+
+
 def check_static() -> list:
     errors = []
     if not os.path.isfile(os.path.join(ROOT, "demo", "robots.txt")):
         errors.append("demo/robots.txt отсутствует (Pages отдаёт /robots.txt)")
+    errors.extend(seo_errors())
     try:
         with open(WORKFLOW, encoding="utf-8") as fh:
             wf = fh.read()
@@ -162,6 +201,19 @@ def selftest() -> int:
     wf_missing = "name: x\nsteps:\n  - run: cp llms.txt demo/\n"
     miss = [n for n in WORKFLOW_REQUIRED if n not in wf_missing]
     case("неполный шаг копирования ловится (негатив)", len(miss) >= 5)
+    case("SEO-страницы на месте и объявлены в sitemap", seo_errors() == [])
+    case("пропавшая SEO-страница ловится (негатив)",
+         seo_errors(demo_root=os.path.join(ROOT, "scripts"),
+                    sitemap_text="") != [])
+    try:
+        with open(os.path.join(ROOT, "demo", "sitemap.xml"),
+                  encoding="utf-8") as fh:
+            sm = fh.read()
+    except OSError:
+        sm = ""
+    case("sitemap без URL SEO-страницы ловится (негатив)",
+         seo_errors(sitemap_text=sm.replace("/oaicite/", "/net-takoi/"))
+         != [])
     print("САМОПРОВЕРКА check_pages_router: %d/%d PASS"
           % (passed, passed + failed))
     return 1 if failed else 0


### PR DESCRIPTION
## Что изменено

Четыре новые статические страницы в `demo/` плюс SEO-механика и расширение гейта машинного маршрута. Сборка Pages не меняется: страницы лежат в `demo/` и публикуются вместе с артефактом.

### SEO-страницы под поисковые запросы

| Запрос | Страница | Как проверено |
|---|---|---|
| `:contentReference[oaicite] что это / как убрать` | `demo/oaicite/index.html` → `/oaicite/` | `python scripts/check_pages_router.py --selftest` (7/7 PASS, в том числе негативы) и статический режим; `humanizer-scan demo/oaicite/index.html --json`: 1 признак (quotes_style — кавычки HTML-атрибутов), столько же у базового `demo/index.html`; JSON-LD FAQPage парсится `json.loads` |
| `удалить невидимые символы chatgpt / водяные знаки U+202F` | `demo/invisible/index.html` → `/invisible/` | то же: `humanizer-scan --json` → 1 признак (quotes_style), JSON-LD FAQPage валиден, один h1 |
| `utm_source=chatgpt.com в тексте что это` | `demo/utm/index.html` → `/utm/` | то же: `humanizer-scan --json` → 1 признак (quotes_style), JSON-LD FAQPage валиден, один h1 |

Факты на страницах взяты только из `research/fixtures/marker-sources.json` (снимки ревизий с датами доступа приведены в текстах и в блоках «Источники») и `references/removal-matrix.md` (классы safe/ambiguous/dangerous, действие U+202F — замена на обычный пробел только в явном режиме). Честные границы на каждой странице: класс A — факт вставки, а не вердикт об авторстве; dangerous-диапазоны не снимаются никогда; обещаний «обход детекторов» нет; текст не покидает машину.

### Статья (расширение области той же ветки)

- `demo/articles/two-humanizer-ru/index.html` — первая авторская статья проекта «Два humanizer-ru: я отозвал свою лучшую метрику и зову тёзку на бенчмарк». Служебный блок исходника в публикацию не вошёл, подпись «Автор: …» сохранена внизу. Числа не правились: все 82 числовых фрагмента исходника присутствуют на странице дословно (сверка скриптом), дословная сверка тела через difflib даёт сходство 0.9976; расхождения — только следствия разметки (нумерация списка переехала в `<ol>`, скобки markdown-ссылки стали тегом `<a>`).
- `humanizer-scan` из venv (`python -m venv .venv-check; pip install -e .`): тело статьи — 0 признаков, видимый текст страницы — 0 признаков, HTML-файл страницы — 1 признак (quotes_style, кавычки атрибутов — как у `demo/index.html`).
- `python scripts/check_outward.py` на исходнике статьи и на HTML-странице: FAIL 0, WARN 0.
- JSON-LD Article (author: Vladimir-Human, publisher: проект humanizer-ru, datePublished 2026-09-11), canonical на себя, `<title>` — заголовок статьи, meta description — первый абзац.

### SEO-механика

- У каждого URL свои `<title>` и meta description, canonical, og-теги, `lang="ru"`, ровно один h1.
- `demo/sitemap.xml`: добавлены 4 URL (lastmod 2026-09-11); `demo/robots.txt`: добавлена строка Sitemap.
- `demo/index.html`: блоки «Разборы следов вставки» и «Статьи» со ссылками на новые страницы, добавлен canonical; обратные ссылки на демо стоят в навигации и подвале каждой новой страницы. Ссылки на сканер идут без URL-фрагмента: fragment в демо по построению переносит текст в поле проверки, якорь на элемент подставлял бы в сканер случайный текст.
- `demo/sw.js` перегенерирован `demo/generate_js_rules.py` (хэш кэша включает index.html); `demo/markers.js` не изменился побайтово.
- Аналитики и трекеров на страницах нет: проект ничего не собирает (PRIVACY_POLICY.md).

### Гейты

- `scripts/check_pages_router.py`: новые страницы добавлены в `PAGES_PATHS` (проверка после деплоя, `--live-pages`) и в статическую проверку `seo_errors()` — файл в `demo/` плюс объявление канонического URL в `demo/sitemap.xml`; selftest расширен двумя негативными кейсами, 7/7 PASS.
- `python scripts/check_all.py --quick`: 145 гейтов, FAIL 0, SKIP 0.
- `python -m unittest discover -s tests`: Ran 480 tests, OK (skipped=12).
- Точечно в режимах CI (demo-pages.yml / validators.yml): `check_demo_parity.py` — OK (node доступен), `check_demo_a11y.py` и `--selftest` — OK, `check_demo_states.py` — OK, `check_pages_router.py` (режим HEAD-ссылок llms.txt + состав workflow + SEO-страницы) — OK, `check_positioning_sync.py` — OK (title/h1/описания demo/index.html не менялись).
- Мягкие признаки новых страниц не выше базового `demo/index.html`: 1 признак против 1 (единственная находка — #18 «кавычки-лапки» из служебных кавычек HTML-атрибутов; счётчик `scripts/scan_soft_signals.py`, он же `humanizer-scan`).
- Гейт no-anglicisms (.github/workflows/no-anglicisms.yml) сканирует только SKILL.md, README.md, GOVERNANCE.md, CONTRIBUTING.md — новые страницы вне его области действия; англицизмы в текстах страниц при этом избегались по стилю проекта.

Не мержить: ветка для ревью.
