### PR TITLE
Update documented gate counts

### DIFF
--- a/docs/USAGE.en.md
+++ b/docs/USAGE.en.md
@@ -256,7 +256,7 @@ Short map; details live in the directories themselves:
 - `tests/fixtures/` — marker and polish fixtures.
 - `action/`, `demo/`, `dsh/` — CI action, browser demo, dsh bundle.
 
-The full checklist runs in one command: `python scripts/check_all.py` — 155 gates in the full checklist (144 in --quick). Unit tests: `python -m unittest discover -s tests`.
+The full checklist runs in one command: `python scripts/check_all.py` — 156 gates in the full checklist (145 in --quick). Unit tests: `python -m unittest discover -s tests`.
 
 ## Security
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -317,7 +317,7 @@ core/app и счётчик `rsid` как контекст, но не доказ�
 - `action/`, `demo/`, `dsh/` — CI-экшен, браузерное демо, бандл dsh.
 - `METRICS.md`, `RELEASE.md`, `identity.v1.json`, `server.json` — витрина измерений, регламент выпусков, машиночитаемая идентичность и метаданные MCP-реестра.
 
-Полный чек-лист — одна команда: `python scripts/check_all.py` — 155 гейтов полного чек-листа (144 в --quick). Юнит-тесты — `python -m unittest discover -s tests`.
+Полный чек-лист — одна команда: `python scripts/check_all.py` — 156 гейтов полного чек-листа (145 в --quick). Юнит-тесты — `python -m unittest discover -s tests`.
 
 ### Содержательные паттерны
 


### PR DESCRIPTION
The docs still stated 155 full gates / 144 quick gates while the current check_all contains 156 / 145 after the distribution receipt gate.

Updated both Russian and English usage guides. Validation:
- check_docs.py PASS
- check_bundle_sync.py PASS
- check_identity.py PASS
- check_all.py --quick --strict: 145/145 PASS
