### PR TITLE
Remove duplicate install step from quickstart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -30,7 +30,7 @@ The Russian profile remains the default for compatibility.
 
 - [Browser demo](https://vladimir-human.github.io/humanizer-ru/): nothing to install, your text never leaves the browser.
 - Report a problem or share usage experience: [an issue in the repository](https://github.com/Vladimir-Human/humanizer-ru/issues/new); user text is never sent automatically by the demo or by the feedback collector.
-- In a terminal:
+- Check a concrete pasted fragment:
 
 The shortest path is “find → clean → verify”:
 
@@ -46,7 +46,6 @@ Cleaning does not rewrite style or meaning: review the result and run
 `humanizer-facts diff before.txt after.txt --no-additions` after editorial edits.
 
 ```text
-pip install humanizer-ru
 python -c "open('primer.txt','w',encoding='utf-8').write('Согласно отчёту :contentReference[oaicite:3]{index=3}, рост заявок.\n')"
 humanizer-markers --scan primer.txt; echo "rc=$?"
   primer.txt:1 [contentReference] Согласно отчёту :contentReference[oaicite:3]{index=3}, рост заявок.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 - [Демо в браузере](https://vladimir-human.github.io/humanizer-ru/): ничего не устанавливать, текст не покидает браузер.
 - Сообщить о проблеме или опыте использования: [issue в репозитории](https://github.com/Vladimir-Human/humanizer-ru/issues/new); пользовательский текст не передаётся автоматически ни демо, ни сборщиком обратной связи.
-- В терминале:
+- Проверка конкретной вставки:
 
 Самый короткий путь «нашёл → убрал → проверил»:
 
@@ -46,7 +46,6 @@ humanizer-markers --scan input.txt       # убедиться, что остат
 `humanizer-facts diff до.txt после.txt --no-additions` после редакторской правки.
 
 ```text
-pip install humanizer-ru
 python -c "open('primer.txt','w',encoding='utf-8').write('Согласно отчёту :contentReference[oaicite:3]{index=3}, рост заявок.\n')"
 humanizer-markers --scan primer.txt; echo "rc=$?"
   primer.txt:1 [contentReference] Согласно отчёту :contentReference[oaicite:3]{index=3}, рост заявок.


### PR DESCRIPTION
The quickstart now has a single install command followed by a concise find → clean → verify path. The second marker example no longer repeats `pip install`, and its heading explains that it checks an already-created pasted fragment.

Checks: check_docs.py, check_examples.py, check_readme_parity.py, git diff --check.
