### PR TITLE
Remove duplicated quickstart block

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -34,19 +34,6 @@ The Russian profile remains the default for compatibility.
 
 The shortest path is “find → clean → verify”:
 
-The shortest path is “find → clean → verify”:
-
-```text
-pip install humanizer-ru
-humanizer-markers --scan input.txt       # find traces (rc=1 = finding)
-humanizer-clean --in-place input.txt     # remove supported artifacts
-humanizer-markers --scan input.txt       # verify no residue (rc=0)
-```
-
-For English input add `--language en`; use `--language auto` for mixed text.
-Cleaning does not rewrite style or meaning: review the result and run
-`humanizer-facts diff before.txt after.txt --no-additions` after editorial edits.
-
 ```text
 pip install humanizer-ru
 humanizer-markers --scan input.txt       # find traces (rc=1 = finding)

--- a/README.md
+++ b/README.md
@@ -34,19 +34,6 @@
 
 Самый короткий путь «нашёл → убрал → проверил»:
 
-Самый короткий путь «нашёл → убрал → проверил»:
-
-```text
-pip install humanizer-ru
-humanizer-markers --scan input.txt       # найти следы (rc=1 = находка)
-humanizer-clean --in-place input.txt     # снять поддержанные артефакты
-humanizer-markers --scan input.txt       # убедиться, что остатка нет (rc=0)
-```
-
-Для английского входа добавьте `--language en`; для смешанного — `--language auto`.
-Очистка не переписывает стиль и смысл: проверьте результат вручную и используйте
-`humanizer-facts diff до.txt после.txt --no-additions` после редакторской правки.
-
 ```text
 pip install humanizer-ru
 humanizer-markers --scan input.txt       # найти следы (rc=1 = находка)


### PR DESCRIPTION
Remove the duplicate quickstart paragraph and command block introduced by the previous documentation merge. Keep the canonical language-profile quickstart exactly once.