### PR TITLE
Prefer checkout contract in MCP conformance

### DIFF
--- a/scripts/mcp/humanizer_mcp.py
+++ b/scripts/mcp/humanizer_mcp.py
@@ -64,7 +64,13 @@ CALL_TIMEOUT = 60
 # ------------------------------------------------------------- контракт
 
 def _contract_path():
-    """contract.v1.json: данные установленного пакета, иначе дерево репо."""
+    """contract.v1.json: checkout data first, installed package in sdist."""
+    # A checkout must win over an older package already installed on the host.
+    here = os.path.dirname(os.path.abspath(__file__))
+    checkout = os.path.join(os.path.dirname(os.path.dirname(here)),
+                            "contract.v1.json")
+    if os.path.isfile(checkout):
+        return checkout
     try:
         from importlib.resources import files
         p = files("humanizer_ru").joinpath("contract.v1.json")
@@ -72,9 +78,7 @@ def _contract_path():
             return str(p)
     except Exception:
         pass
-    here = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(os.path.dirname(os.path.dirname(here)),
-                        "contract.v1.json")
+    return checkout
 
 
 def load_contract(path=None):

--- a/src/humanizer_ru/mcp_server.py
+++ b/src/humanizer_ru/mcp_server.py
@@ -64,7 +64,13 @@ CALL_TIMEOUT = 60
 # ------------------------------------------------------------- контракт
 
 def _contract_path():
-    """contract.v1.json: данные установленного пакета, иначе дерево репо."""
+    """contract.v1.json: checkout data first, installed package in sdist."""
+    # A checkout must win over an older package already installed on the host.
+    here = os.path.dirname(os.path.abspath(__file__))
+    checkout = os.path.join(os.path.dirname(os.path.dirname(here)),
+                            "contract.v1.json")
+    if os.path.isfile(checkout):
+        return checkout
     try:
         from importlib.resources import files
         p = files("humanizer_ru").joinpath("contract.v1.json")
@@ -72,9 +78,7 @@ def _contract_path():
             return str(p)
     except Exception:
         pass
-    here = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(os.path.dirname(os.path.dirname(here)),
-                        "contract.v1.json")
+    return checkout
 
 
 def load_contract(path=None):


### PR DESCRIPTION
When an older humanizer-ru is installed, MCP conformance must validate the current checkout. Prefer the repository contract when present, while retaining the installed-package fallback for source distributions.