### PR TITLE
Require confirmation before sharing demo text

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -39,6 +39,9 @@
   .match { font-family: "Courier New", monospace; font-size:13px; color:#333; }
   .controls { display:flex; gap:12px; flex-wrap:wrap; align-items:center; }
   button { padding:8px 14px; border:0; border-radius:6px; background:#1f6f4a; color:#fff; cursor:pointer; }
+  dialog { max-width:32rem; padding:20px; border:1px solid var(--line); border-radius:6px; background:var(--panel); color:var(--fg); }
+  #shareDialog button { color:var(--bg); }
+  dialog::backdrop { background:rgb(0 0 0 / 45%); }
   .note { color:#666; font-size:13px; }
   summary { cursor:pointer; font-weight:bold; }
 </style>
@@ -66,6 +69,16 @@
     <span id="summary" class="note" aria-live="polite"></span>
 <span id="scanState" class="rule" role="status" aria-live="polite"></span>
   </div>
+  <dialog id="shareDialog" aria-labelledby="shareHeading" aria-describedby="shareWarning">
+    <h2 id="shareHeading">Создать ссылку с текстом?</h2>
+    <p id="shareWarning">Ссылка получит ваш текст целиком. Он останется в истории браузера
+      и может попасть в синхронизацию. Любой получатель ссылки сможет прочитать текст.
+      Не создавайте ссылку с личными или конфиденциальными сведениями.</p>
+    <form method="dialog" class="controls">
+      <button value="cancel" autofocus>Отмена</button>
+      <button value="share">Создать ссылку с текстом</button>
+    </form>
+  </dialog>
   <div class="cols">
     <section>
       <h2 id="textHeading">Текст</h2>
@@ -291,20 +304,40 @@
       st.textContent = "буфер обмена недоступен";
     }
   });
-  document.getElementById("shareBtn").addEventListener("click", () => {
+  const shareDialog = document.getElementById("shareDialog");
+  function shareableText() {
     const text = textarea.value;
+    if (!text.trim()) {
+      summary.textContent = "Сначала вставьте текст, которым хотите поделиться.";
+      return null;
+    }
     // N33: лимит считаем в байтах ПОСЛЕ кодирования, не в символах.
-    const bytes = new TextEncoder().encode(encodeURIComponent(text)).length;
+    let bytes;
+    try {
+      bytes = new TextEncoder().encode(encodeURIComponent(text)).length;
+    } catch (e) {
+      summary.textContent = "Текст содержит повреждённый символ — ссылка не создаётся.";
+      return null;
+    }
     if (bytes > 65536) {
       summary.textContent = "Текст после кодирования длиннее 64 КиБ — " +
         "ссылка не создаётся.";
-      return;
+      return null;
     }
-    // Предупреждение ДО помещения текста в URL.
-    summary.textContent = "Ссылка получит ваш текст: история браузера, " +
-      "синхронизация и пересылка ссылки раскрывают его; fragment не " +
-      "отправляется серверу, но остаётся в истории и копируется ссылкой.";
+    return text;
+  }
+  document.getElementById("shareBtn").addEventListener("click", () => {
+    if (shareableText() === null) return;
+    // Reset the previous decision: Escape after a successful share is cancellation.
+    shareDialog.returnValue = "";
+    shareDialog.showModal();
+  });
+  shareDialog.addEventListener("close", () => {
+    if (shareDialog.returnValue !== "share") return;
+    const text = shareableText();
+    if (text === null) return;
     location.hash = encodeURIComponent(text);
+    summary.textContent = "Ссылка с текстом создана. Скопируйте адрес из строки браузера.";
   });
   document.addEventListener("keydown", (e) => {
     if ((e.ctrlKey || e.metaKey) && e.key === "Enter") { e.preventDefault(); run(); }

--- a/demo/sw.js
+++ b/demo/sw.js
@@ -1,5 +1,5 @@
 /* Автогенерация generate_js_rules.py: кэш версионируется хэшем правил, движка, образца и страницы. */
-const CACHE = "humanizer-ru-99bc3bf907e1";
+const CACHE = "humanizer-ru-0bc9612a909d";
 const STATIC = ["./", "./index.html", "./brand.css", "./markers.js",
   "./engine.js", "./sample.js", "./favicon.svg", "./manifest.json"];
 self.addEventListener("install", (e) => {

--- a/eval/facts/self-audit.v1.json
+++ b/eval/facts/self-audit.v1.json
@@ -1,8 +1,8 @@
 {
   "registry": "humanizer-ru self-audit: самоприменение детерминированного слоя к публичным файлам поставки",
   "version": "3.36.0",
-  "date": "2026-09-11",
-  "measured_commit": "726f9f6a8b180703ab0d1a4fb5289ad07af7c83c",
+  "date": "2026-09-12",
+  "measured_commit": "683648154c88f7d0e449757f9f42c0f8b41d5737",
   "commit_note": "числа измерены на рабочем дереве; отчёт-committed рядом с измеряемыми правками — сам отчёт в скоуп измерения не входит, поэтому числа соответствуют дереву коммита, содержащего отчёт",
   "scope_files": 44,
   "methods": {
@@ -45,7 +45,7 @@
       "markers_b": 0,
       "scan_features": 1,
       "scan_categories": 1,
-      "style_total": 37,
+      "style_total": 38,
       "detect_status": "not-applicable",
       "detect_genre": "web",
       "detect_note": "значения сравниваются только в пределах заявленного домена; вердикт об авторстве не выносится"

--- a/tests/test_demo_sharing.py
+++ b/tests/test_demo_sharing.py
@@ -1,0 +1,140 @@
+"""Regression tests for the demo's consent-gated share flow."""
+
+import json
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "demo" / "index.html"
+
+
+def _inline_app() -> str:
+    source = PAGE.read_text(encoding="utf-8")
+    match = re.search(r"<script>\s*(\(\(\) => \{.*?\n\}\)\(\);)\s*</script>", source, re.S)
+    if not match:
+        raise AssertionError("demo inline application script was not found")
+    return match.group(1)
+
+
+NODE_HARNESS = r"""
+const vm = require('vm');
+const app = __APP__;
+const elements = new Map();
+function element(id) {
+  const handlers = Object.create(null);
+  const e = {
+    id, value: '', checked: id === 'showAll', innerHTML: '', textContent: '',
+    returnValue: '', focused: false, shown: 0,
+    addEventListener(type, fn) { (handlers[type] ||= []).push(fn); },
+    emit(type, event = {}) { for (const fn of (handlers[type] || [])) fn(event); },
+    focus() { this.focused = true; },
+    showModal() { this.shown++; },
+    appendChild() {},
+  };
+  elements.set(id, e); return e;
+}
+for (const id of ['text', 'matches', 'preview', 'summary', 'onlyA', 'showAll',
+                  'run', 'insertSample', 'ownText', 'copyReport', 'copyStatus',
+                  'shareBtn', 'counts', 'scanState', 'shareDialog']) element(id);
+const documentHandlers = Object.create(null);
+const document = {
+  getElementById(id) { return elements.get(id) || element(id); },
+  createElement() { return { className: '', innerHTML: '', appendChild() {} }; },
+  addEventListener(type, fn) { (documentHandlers[type] ||= []).push(fn); },
+};
+let hash = '';
+let hashWrites = 0;
+const location = {
+  pathname: '/', search: '',
+  get hash() { return hash; },
+  set hash(value) { hash = value && value[0] === '#' ? value : '#' + value; hashWrites++; },
+};
+const context = {
+  document, location, navigator: {}, history: { replaceState() {} },
+  HUMANIZER_MARKERS: { rules: [] }, HUMANIZER_SAMPLE: '',
+  TextEncoder, encodeURIComponent, decodeURIComponent, setTimeout, clearTimeout,
+  console, JSON, Object, String, Array, RegExp, Error,
+};
+vm.runInNewContext(app, context, { filename: 'demo/index.html' });
+const text = elements.get('text');
+const share = elements.get('shareBtn');
+const dialog = elements.get('shareDialog');
+function click() { share.emit('click'); }
+  function close(value) { dialog.returnValue = value; dialog.emit('close'); }
+  // Model Escape as the dialog's close event without rewriting returnValue.
+  // The page must reset it before every showModal() call.
+  function escapeDialog() { dialog.emit('close'); }
+function result() {
+  text.value = '';
+  click();
+  const empty = { shown: dialog.shown, writes: hashWrites, hash };
+  text.value = 'проверяемый текст';
+  click();
+  const pending = { shown: dialog.shown, writes: hashWrites, hash };
+  close('cancel');
+  const cancelled = { writes: hashWrites, hash };
+  text.value = 'текущий текст';
+  click(); close('share');
+  const confirmed = { writes: hashWrites, hash, expected: encodeURIComponent('текущий текст') };
+  text.value = 'новый текст после ссылки';
+  click(); escapeDialog();
+  const escaped = { writes: hashWrites, hash };
+  text.value = 'a'.repeat(65536);
+  const beforeBoundary = { shown: dialog.shown, writes: hashWrites, hash };
+  click();
+  const boundary = { shown: dialog.shown, writes: hashWrites, hash };
+  close('cancel');
+  text.value = 'a'.repeat(65537);
+  const beforeOversize = { shown: dialog.shown, writes: hashWrites, hash };
+  click();
+  const oversize = { shown: dialog.shown, writes: hashWrites, hash };
+  text.value = '\ud800';
+  const beforeMalformed = { shown: dialog.shown, writes: hashWrites, hash };
+  click();
+  const malformed = { shown: dialog.shown, writes: hashWrites, hash };
+  return { empty, pending, cancelled, confirmed, escaped, boundary, oversize,
+           beforeBoundary, beforeOversize, malformed, beforeMalformed };
+}
+process.stdout.write(JSON.stringify(result()));
+"""
+
+
+class DemoSharingTests(unittest.TestCase):
+    def test_share_requires_explicit_confirmation_and_uses_current_text(self):
+        if not PAGE.exists():
+            if (ROOT / ".git").exists():
+                self.fail("demo/index.html отсутствует в checkout")
+            self.skipTest("demo/index.html не входит в sdist")
+        node = shutil.which("node")
+        self.assertIsNotNone(node, "node не найден: demo sharing regression requires Node.js")
+        script = NODE_HARNESS.replace("__APP__", json.dumps(_inline_app()))
+        proc = subprocess.run([node, "-e", script], cwd=ROOT, text=True,
+                              capture_output=True, encoding="utf-8", timeout=30)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        data = json.loads(proc.stdout)
+
+        self.assertEqual(data["empty"]["writes"], 0)
+        self.assertEqual(data["empty"]["shown"], 0)
+        self.assertEqual(data["pending"]["shown"], 1)
+        self.assertEqual(data["pending"]["writes"], 0)
+        self.assertEqual(data["cancelled"]["writes"], 0)
+        self.assertEqual(data["confirmed"]["hash"], "#" + data["confirmed"]["expected"])
+        self.assertEqual(data["confirmed"]["writes"], 1)
+        self.assertEqual(data["escaped"]["hash"], data["confirmed"]["hash"])
+        self.assertEqual(data["escaped"]["writes"], 1)
+        self.assertEqual(data["boundary"]["shown"], data["beforeBoundary"]["shown"] + 1)
+        self.assertEqual(data["boundary"]["writes"], 1)
+        self.assertEqual(data["oversize"]["hash"], data["confirmed"]["hash"])
+        self.assertEqual(data["oversize"]["writes"], 1)
+        self.assertEqual(data["oversize"]["shown"], data["beforeOversize"]["shown"])
+        self.assertEqual(data["malformed"]["hash"], data["confirmed"]["hash"])
+        self.assertEqual(data["malformed"]["writes"], 1)
+        self.assertEqual(data["malformed"]["shown"], data["beforeMalformed"]["shown"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- require an explicit native dialog confirmation before putting pasted text into the URL fragment
- preserve the previous link on cancel or Escape and validate the current text again before sharing
- add a Node regression test for empty, boundary, malformed, cancel, Escape, and confirmed paths

## Validation

- `python -X utf8 scripts/check_all.py --quick --strict` (145/145)
- `python -X utf8 scripts/check_all.py --strict` (156/156)
- `python -X utf8 scripts/check_demo_browser.py --url http://127.0.0.1:8479/index.html`
- `python -X utf8 -m unittest discover -s tests -p test_demo_sharing.py -v`
- installed wheel user journeys (11/11)
