### PR TITLE
Expose cleanup path from demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -43,6 +43,9 @@
   #shareDialog button { color:var(--bg); }
   dialog::backdrop { background:rgb(0 0 0 / 45%); }
   .note { color:#666; font-size:13px; }
+  .next-step { padding:12px 14px; border:1px solid var(--line); border-left:5px solid #1f6f4a; border-radius:6px; background:var(--panel); }
+  .next-step h2 { margin-top:0; }
+  .next-step a { color:#1558a6; font-weight:bold; }
   summary { cursor:pointer; font-weight:bold; }
 </style>
   <meta name="twitter:image" content="https://vladimir-human.github.io/humanizer-ru/og-image.png">
@@ -93,6 +96,12 @@
     <h2>Текст с подсветкой <span class="rule">(красный — класс A, жёлтый — класс B)</span></h2>
     <pre id="preview"></pre>
   </section>
+  <aside class="next-step" aria-labelledby="nextStepHeading">
+    <h2 id="nextStepHeading">Нужно убрать найденные артефакты?</h2>
+    <p>Демо только проверяет текст. Для поддерживаемой очистки установите пакет
+      и выполните короткий путь «найти → убрать → проверить» в README.</p>
+    <a href="https://github.com/Vladimir-Human/humanizer-ru#попробовать-за-30-секунд">Открыть команду humanizer-clean</a>
+  </aside>
 </main>
 
 <script>


### PR DESCRIPTION
## Summary

- expose the supported `humanizer-clean` path directly from the browser demo
- keep the demo boundary explicit: the page checks and explains, the CLI performs cleanup

## Validation

- `python -X utf8 scripts/check_demo_a11y.py`
- `python -X utf8 scripts/check_demo_states.py`
- `python -X utf8 scripts/check_demo_browser.py --url http://127.0.0.1:8479/index.html`
