### PR TITLE
Show cleanup command in demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -100,6 +100,9 @@
     <h2 id="nextStepHeading">Нужно убрать найденные артефакты?</h2>
     <p>Демо только проверяет текст. Для поддерживаемой очистки установите пакет
       и выполните короткий путь «найти → убрать → проверить» в README.</p>
+    <pre><code>pip install humanizer-ru
+humanizer-clean --in-place input.txt
+humanizer-markers --scan input.txt</code></pre>
     <a href="https://github.com/Vladimir-Human/humanizer-ru#попробовать-за-30-секунд">Открыть команду humanizer-clean</a>
   </aside>
 </main>

--- a/demo/sw.js
+++ b/demo/sw.js
@@ -1,5 +1,5 @@
 /* Автогенерация generate_js_rules.py: кэш версионируется хэшем правил, движка, образца и страницы. */
-const CACHE = "humanizer-ru-0bc9612a909d";
+const CACHE = "humanizer-ru-6f3a284d7721";
 const STATIC = ["./", "./index.html", "./brand.css", "./markers.js",
   "./engine.js", "./sample.js", "./favicon.svg", "./manifest.json"];
 self.addEventListener("install", (e) => {


### PR DESCRIPTION
## Summary

- show the verified cleanup command directly in the demo's next-step panel
- keep the browser boundary explicit: the page checks locally, the CLI cleans locally

## Validation

- `python -X utf8 scripts/check_demo_a11y.py`
- `python -X utf8 scripts/check_demo_states.py`
- `python -X utf8 scripts/check_demo_browser.py --url http://127.0.0.1:8479/index.html`
