### PR TITLE
Protect local text and improve demo accessibility

### DIFF
--- a/demo/brand.css
+++ b/demo/brand.css
@@ -3,6 +3,8 @@
 :root {
   --accent1: #2f6feb;
   --accent2: #8250df;
+  --button-fg: #ffffff;
+  --link: #1558a6;
   --bg: #f6f5f2;
   --fg: #1f1d1a;
   --line: #d9d5cc;
@@ -15,6 +17,8 @@
   :root {
     --accent1: #79b8ff;
     --accent2: #d2a8ff;
+    --button-fg: #0d1117;
+    --link: #a8d1ff;
     --bg: #0d1117;
     --fg: #e6edf3;
     --line: #30363d;
@@ -26,7 +30,9 @@ body { background: var(--bg); color: var(--fg); font-family: var(--font-body); }
 header, footer { background: var(--panel); }
 textarea, #preview, .result { background: var(--panel); color: var(--fg); border-color: var(--line); }
 .rule, .note { color: var(--muted); }
-button { background: var(--accent1); }
+button { background: var(--accent1); color: var(--button-fg); }
+a { color: var(--link); }
+:focus-visible { outline: 2px solid var(--accent1); outline-offset: 3px; }
 @media (prefers-color-scheme: dark) {
   mark.a { background: #5c2b29; outline-color: #ff8f88; }
   mark.b { background: #4d3b00; outline-color: #e3b341; }

--- a/demo/index.html
+++ b/demo/index.html
@@ -46,7 +46,7 @@
   .next-step { padding:12px 14px; border:1px solid var(--line); border-left:5px solid #1f6f4a; border-radius:6px; background:var(--panel); }
   .next-step h2 { margin-top:0; }
   .next-step pre { max-width:100%; box-sizing:border-box; white-space:pre-wrap; overflow-wrap:anywhere; overflow:auto; }
-  .next-step a { color:#1558a6; font-weight:bold; }
+  .next-step a { color:var(--link); font-weight:bold; }
   summary { cursor:pointer; font-weight:bold; }
 </style>
   <meta name="twitter:image" content="https://vladimir-human.github.io/humanizer-ru/og-image.png">
@@ -65,7 +65,7 @@
     <label><input type="checkbox" id="showAll" checked> показывать полный текст с подсветкой</label>
     <button id="run">Проверить</button>
     <button id="insertSample" type="button" title="Реальная вставка из чат-интерфейса: contentReference, utm-метка, невидимый символ">Вставить образец</button>
-    <button id="ownText" type="button">Проверить свой</button>
+    <button id="ownText" type="button">Очистить поле</button>
     <button id="copyReport" type="button">Скопировать отчёт</button>
     <span id="copyStatus" role="status" aria-live="polite"></span>
     <button id="shareBtn" type="button">Поделиться</button>
@@ -175,6 +175,7 @@ humanizer-markers --scan input.txt</code></pre>
   }
 
   function renderPreview(text, matches) {
+    document.getElementById("previewSection").hidden = !text.trim();
     if (!showAll.checked) { preview.textContent = text; return; }
     const ranges = mergedRanges(matches);
     let html = "";
@@ -285,6 +286,7 @@ humanizer-markers --scan input.txt</code></pre>
     textarea.value = "";
     // N33: переход к своему тексту очищает share-state в URL.
     history.replaceState(null, "", location.pathname + location.search);
+    hasShareHash = false;
     textarea.focus();
     updateCounts();
     run();
@@ -350,13 +352,22 @@ humanizer-markers --scan input.txt</code></pre>
     const text = shareableText();
     if (text === null) return;
     location.hash = encodeURIComponent(text);
+    hasShareHash = true;
     summary.textContent = "Ссылка с текстом создана. Скопируйте адрес из строки браузера.";
   });
   document.addEventListener("keydown", (e) => {
     if ((e.ctrlKey || e.metaKey) && e.key === "Enter") { e.preventDefault(); run(); }
   });
   let _timer;
+  let hasShareHash = location.hash.length > 1;
   textarea.addEventListener("input", () => {
+    // Editing text loaded from a share link invalidates that link. Remove the
+    // old fragment before the next debounce so a copied URL cannot expose the
+    // previous text after the user starts replacing it.
+    if (hasShareHash) {
+      history.replaceState(null, "", location.pathname + location.search);
+      hasShareHash = false;
+    }
     clearTimeout(_timer);
     updateCounts();
     _timer = setTimeout(run, 250);

--- a/demo/index.html
+++ b/demo/index.html
@@ -286,7 +286,6 @@ humanizer-markers --scan input.txt</code></pre>
     textarea.value = "";
     // N33: переход к своему тексту очищает share-state в URL.
     history.replaceState(null, "", location.pathname + location.search);
-    hasShareHash = false;
     textarea.focus();
     updateCounts();
     run();
@@ -352,21 +351,18 @@ humanizer-markers --scan input.txt</code></pre>
     const text = shareableText();
     if (text === null) return;
     location.hash = encodeURIComponent(text);
-    hasShareHash = true;
     summary.textContent = "Ссылка с текстом создана. Скопируйте адрес из строки браузера.";
   });
   document.addEventListener("keydown", (e) => {
     if ((e.ctrlKey || e.metaKey) && e.key === "Enter") { e.preventDefault(); run(); }
   });
   let _timer;
-  let hasShareHash = location.hash.length > 1;
   textarea.addEventListener("input", () => {
     // Editing text loaded from a share link invalidates that link. Remove the
     // old fragment before the next debounce so a copied URL cannot expose the
     // previous text after the user starts replacing it.
-    if (hasShareHash) {
+    if (location.hash.length > 1) {
       history.replaceState(null, "", location.pathname + location.search);
-      hasShareHash = false;
     }
     clearTimeout(_timer);
     updateCounts();

--- a/demo/sw.js
+++ b/demo/sw.js
@@ -1,5 +1,5 @@
 /* Автогенерация generate_js_rules.py: кэш версионируется хэшем правил, движка, образца и страницы. */
-const CACHE = "humanizer-ru-6f3a284d7721";
+const CACHE = "humanizer-ru-c37a2214a906";
 const STATIC = ["./", "./index.html", "./brand.css", "./markers.js",
   "./engine.js", "./sample.js", "./favicon.svg", "./manifest.json"];
 self.addEventListener("install", (e) => {

--- a/demo/sw.js
+++ b/demo/sw.js
@@ -1,5 +1,5 @@
 /* Автогенерация generate_js_rules.py: кэш версионируется хэшем правил, движка, образца и страницы. */
-const CACHE = "humanizer-ru-c37a2214a906";
+const CACHE = "humanizer-ru-c1cf196c7164";
 const STATIC = ["./", "./index.html", "./brand.css", "./markers.js",
   "./engine.js", "./sample.js", "./favicon.svg", "./manifest.json"];
 self.addEventListener("install", (e) => {

--- a/scripts/filemarks/text_layer.py
+++ b/scripts/filemarks/text_layer.py
@@ -29,30 +29,32 @@ def _assert_safe_destination(path):
 
 
 def _safe_write_text(path, text):
-    """Write UTF-8 text through a private, atomic, symlink-safe temp file."""
+    """Write atomically; preserve existing permissions and reject symlinks.
+
+    Parent checks are best-effort, not protection against a concurrent rename
+    of a parent directory. New backup files keep mkstemp's private mode.
+    """
     dest = Path(path)
     _assert_safe_destination(dest)
     parent = dest.parent
+    mode = (dest.stat().st_mode & 0o777) if dest.exists() else 0o600
     fd, tmp_name = tempfile.mkstemp(
         prefix="." + dest.name + ".", suffix=".tmp", dir=str(parent))
     try:
-        mask = os.umask(0)
-        os.umask(mask)
-        mode = 0o666 & ~mask
-        try:
-            os.fchmod(fd, mode)
-        except AttributeError:  # pragma: no cover - Windows
-            os.chmod(tmp_name, mode)
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fd = None  # The stream now owns the descriptor, including on error.
             fh.write(text)
             fh.flush()
             os.fsync(fh.fileno())
+            if os.name != "nt":
+                os.fchmod(fh.fileno(), mode)
         os.replace(tmp_name, dest)
     except BaseException:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             os.unlink(tmp_name)
         except OSError:

--- a/scripts/filemarks/text_layer.py
+++ b/scripts/filemarks/text_layer.py
@@ -8,8 +8,56 @@
 снимаемые доказуемо безпотерно. Снятие детерминированное и проверяемое
 повторным прогоном детектора.
 """
+import os
 import re
+import tempfile
 import unicodedata
+from pathlib import Path
+
+
+def _assert_safe_destination(path):
+    """Reject a destination or any parent that is a symbolic link."""
+    dest = Path(path)
+    probe = dest
+    while True:
+        if probe.is_symlink():
+            raise OSError("отказ писать через симлинк в цепочке: %s" % probe)
+        parent = probe.parent
+        if parent == probe:
+            break
+        probe = parent
+
+
+def _safe_write_text(path, text):
+    """Write UTF-8 text through a private, atomic, symlink-safe temp file."""
+    dest = Path(path)
+    _assert_safe_destination(dest)
+    parent = dest.parent
+    fd, tmp_name = tempfile.mkstemp(
+        prefix="." + dest.name + ".", suffix=".tmp", dir=str(parent))
+    try:
+        mask = os.umask(0)
+        os.umask(mask)
+        mode = 0o666 & ~mask
+        try:
+            os.fchmod(fd, mode)
+        except AttributeError:  # pragma: no cover - Windows
+            os.chmod(tmp_name, mode)
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, dest)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 _MARKER_CASES = {}
 _CM_IS_URL_MARKER = None
@@ -979,20 +1027,17 @@ def clean_main(argv=None) -> int:
                         # Атомарность: копия .bak, запись во временный файл
                         # и os.replace; ошибка записи оставляет исходный
                         # файл целым (состояние уходит в errors, код 2).
-                        tmp = path + ".tmp-clean"
                         try:
-                            with open(path + ".bak", "w", encoding="utf-8",
-                                      newline="") as fh:
-                                fh.write(before)
-                            with open(tmp, "w", encoding="utf-8",
-                                      newline="") as fh:
-                                fh.write(cleaned)
-                            os.replace(tmp, path)
+                            # Validate both destinations before touching the
+                            # backup, then use private mkstemp files for the
+                            # backup and replacement.  This prevents a
+                            # predictable temp path or symlink parent from
+                            # redirecting an in-place write.
+                            _assert_safe_destination(path)
+                            _assert_safe_destination(path + ".bak")
+                            _safe_write_text(path + ".bak", before)
+                            _safe_write_text(path, cleaned)
                         except OSError as exc:
-                            try:
-                                os.unlink(tmp)
-                            except OSError:
-                                pass
                             print("НЕ ЗАПИСАНО %s: %r (исходный файл не "
                                   "изменён)" % (path, exc), file=sys.stderr)
                             errors.append({"file": label,

--- a/scripts/mcp/humanizer_mcp.py
+++ b/scripts/mcp/humanizer_mcp.py
@@ -284,6 +284,53 @@ def _tool_argv(tool_name, arguments, text_path):
 
 MAX_TEXT_CHARS = 1000000
 
+# MCP results must not expose the host's temporary directory (which commonly
+# contains the local username).  The command line tools still receive and
+# report their real paths; only the MCP envelope is normalized.
+_MCP_INPUT_PLACEHOLDER = "<input.txt>"
+_MCP_AFTER_PLACEHOLDER = "<input.txt.after>"
+
+
+def _path_under_temp(value, temp_root):
+    """Return a stable placeholder for a generated temp path, if applicable."""
+    if not isinstance(value, str) or not temp_root:
+        return value
+    # Child processes on Windows may render backslashes while tests or a
+    # compatible host use forward slashes.  Compare a canonical slash form
+    # without changing user text in non-path fields.
+    raw = value.replace("\\", "/")
+    root = os.path.abspath(temp_root).replace("\\", "/").rstrip("/")
+    root_cmp = root.casefold()
+    raw_cmp = raw.casefold()
+    if raw_cmp == root_cmp + "/input.txt":
+        return _MCP_INPUT_PLACEHOLDER
+    if raw_cmp == root_cmp + "/input.txt.after":
+        return _MCP_AFTER_PLACEHOLDER
+    prefix = root_cmp + "/"
+    if raw_cmp.startswith(prefix):
+        # Preserve only a relative generated filename, never the host prefix.
+        suffix = raw[len(root) + 1:]
+        return "<mcp-temp>/" + suffix
+    return value
+
+
+def _sanitize_envelope(value, temp_root, key=None):
+    """Copy an MCP envelope while replacing generated path metadata only.
+
+    Text fields are deliberately left untouched: input text and marker
+    fragments are user data and must not be rewritten just because they happen
+    to contain a path-like string.  Path-bearing MCP metadata uses ``file``,
+    ``files``, ``before`` and ``after`` keys in the seven tool envelopes.
+    """
+    if isinstance(value, dict):
+        return {k: _sanitize_envelope(v, temp_root, k)
+                for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_envelope(v, temp_root, key) for v in value]
+    if isinstance(value, str) and key in {"file", "files", "before", "after"}:
+        return _path_under_temp(value, temp_root)
+    return value
+
 
 def _validate_args(tool_name, arguments, tool_defs):
     """Лишние параметры и enum — единая валидация для всех веток (L9)."""
@@ -299,7 +346,7 @@ def _validate_args(tool_name, arguments, tool_defs):
     return None
 
 
-def _result_from_proc(proc):
+def _result_from_proc(proc, temp_root=None):
     """L9-семантика результата: rc вне {0,1,2} (крах) или непарсящийся вывод
     — isError:true и БЕЗ сырого stdout/stderr: traceback может содержать
     цитаты входного текста и не должен доставляться как «успех»."""
@@ -318,6 +365,8 @@ def _result_from_proc(proc):
         envelope = parsed
     else:
         envelope = None
+    if envelope is not None:
+        envelope = _sanitize_envelope(envelope, temp_root)
     if proc.returncode not in (0, 1, 2):
         content = []
         if envelope is not None:
@@ -389,7 +438,7 @@ def call_tool(tool_name, arguments, tool_defs):
                                   stderr=subprocess.PIPE,
                                   timeout=CALL_TIMEOUT, encoding="utf-8",
                                   errors="replace")
-            result, _env = _result_from_proc(proc)
+            result, _env = _result_from_proc(proc, tmp)
             return result, None
         except UnicodeError as exc:
             return {"content": [{"type": "text",
@@ -432,7 +481,7 @@ def call_tool(tool_name, arguments, tool_defs):
                                  "text": "таймаут инструмента (%d с)"
                                          % CALL_TIMEOUT}],
                     "isError": True}, None
-        result, envelope = _result_from_proc(proc)
+        result, envelope = _result_from_proc(proc, tmp)
         if (tool_name == "humanizer_polish" and proc.returncode in (0, 1)
                 and envelope is not None):
             # Второй прогон без --json: сам нормализованный текст

--- a/scripts/polish.py
+++ b/scripts/polish.py
@@ -95,30 +95,32 @@ def _assert_safe_destination(path):
 
 
 def _safe_write_text(path, text):
-    """Write UTF-8 text through a private, atomic, symlink-safe temp file."""
+    """Write atomically; preserve existing permissions and reject symlinks.
+
+    Parent checks are best-effort, not protection against a concurrent rename
+    of a parent directory. New backup files keep mkstemp's private mode.
+    """
     dest = Path(path)
     _assert_safe_destination(dest)
     parent = dest.parent
+    mode = (dest.stat().st_mode & 0o777) if dest.exists() else 0o600
     fd, tmp_name = tempfile.mkstemp(
         prefix="." + dest.name + ".", suffix=".tmp", dir=str(parent))
     try:
-        mask = os.umask(0)
-        os.umask(mask)
-        mode = 0o666 & ~mask
-        try:
-            os.fchmod(fd, mode)
-        except AttributeError:  # pragma: no cover - Windows
-            os.chmod(tmp_name, mode)
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fd = None  # The stream now owns the descriptor, including on error.
             fh.write(text)
             fh.flush()
             os.fsync(fh.fileno())
+            if os.name != "nt":
+                os.fchmod(fh.fileno(), mode)
         os.replace(tmp_name, dest)
     except BaseException:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             os.unlink(tmp_name)
         except OSError:

--- a/scripts/polish.py
+++ b/scripts/polish.py
@@ -77,6 +77,53 @@ import json
 import os
 import re
 import sys
+import tempfile
+from pathlib import Path
+
+
+def _assert_safe_destination(path):
+    """Reject a destination or any parent that is a symbolic link."""
+    dest = Path(path)
+    probe = dest
+    while True:
+        if probe.is_symlink():
+            raise OSError("отказ писать через симлинк в цепочке: %s" % probe)
+        parent = probe.parent
+        if parent == probe:
+            break
+        probe = parent
+
+
+def _safe_write_text(path, text):
+    """Write UTF-8 text through a private, atomic, symlink-safe temp file."""
+    dest = Path(path)
+    _assert_safe_destination(dest)
+    parent = dest.parent
+    fd, tmp_name = tempfile.mkstemp(
+        prefix="." + dest.name + ".", suffix=".tmp", dir=str(parent))
+    try:
+        mask = os.umask(0)
+        os.umask(mask)
+        mode = 0o666 & ~mask
+        try:
+            os.fchmod(fd, mode)
+        except AttributeError:  # pragma: no cover - Windows
+            os.chmod(tmp_name, mode)
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, dest)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")
@@ -651,20 +698,17 @@ def main(argv=None) -> int:
                     # подмена (tmp + os.replace). Ошибка записи не оставляет
                     # частичный «успешный» результат: исходный файл цел,
                     # временный убирается, состояние уходит в errors с кодом 2.
-                    tmp = path + ".tmp-polish"
                     try:
-                        with open(path + ".bak", "w", encoding="utf-8",
-                                  newline="") as fh:
-                            fh.write(before)
-                        with open(tmp, "w", encoding="utf-8",
-                                  newline="") as fh:
-                            fh.write(after)
-                        os.replace(tmp, path)
+                        # Validate both destinations before touching the
+                        # backup, then use private mkstemp files for the
+                        # backup and replacement.  This prevents a
+                        # predictable temp path or symlink parent from
+                        # redirecting an in-place write.
+                        _assert_safe_destination(path)
+                        _assert_safe_destination(path + ".bak")
+                        _safe_write_text(path + ".bak", before)
+                        _safe_write_text(path, after)
                     except OSError as exc:
-                        try:
-                            os.unlink(tmp)
-                        except OSError:
-                            pass
                         print("НЕ ЗАПИСАНО %s: %r (исходный файл не изменён)"
                               % (path, exc), file=sys.stderr)
                         errors.append({"file": path, "error": repr(exc)})

--- a/src/humanizer_ru/mcp_server.py
+++ b/src/humanizer_ru/mcp_server.py
@@ -284,6 +284,53 @@ def _tool_argv(tool_name, arguments, text_path):
 
 MAX_TEXT_CHARS = 1000000
 
+# MCP results must not expose the host's temporary directory (which commonly
+# contains the local username).  The command line tools still receive and
+# report their real paths; only the MCP envelope is normalized.
+_MCP_INPUT_PLACEHOLDER = "<input.txt>"
+_MCP_AFTER_PLACEHOLDER = "<input.txt.after>"
+
+
+def _path_under_temp(value, temp_root):
+    """Return a stable placeholder for a generated temp path, if applicable."""
+    if not isinstance(value, str) or not temp_root:
+        return value
+    # Child processes on Windows may render backslashes while tests or a
+    # compatible host use forward slashes.  Compare a canonical slash form
+    # without changing user text in non-path fields.
+    raw = value.replace("\\", "/")
+    root = os.path.abspath(temp_root).replace("\\", "/").rstrip("/")
+    root_cmp = root.casefold()
+    raw_cmp = raw.casefold()
+    if raw_cmp == root_cmp + "/input.txt":
+        return _MCP_INPUT_PLACEHOLDER
+    if raw_cmp == root_cmp + "/input.txt.after":
+        return _MCP_AFTER_PLACEHOLDER
+    prefix = root_cmp + "/"
+    if raw_cmp.startswith(prefix):
+        # Preserve only a relative generated filename, never the host prefix.
+        suffix = raw[len(root) + 1:]
+        return "<mcp-temp>/" + suffix
+    return value
+
+
+def _sanitize_envelope(value, temp_root, key=None):
+    """Copy an MCP envelope while replacing generated path metadata only.
+
+    Text fields are deliberately left untouched: input text and marker
+    fragments are user data and must not be rewritten just because they happen
+    to contain a path-like string.  Path-bearing MCP metadata uses ``file``,
+    ``files``, ``before`` and ``after`` keys in the seven tool envelopes.
+    """
+    if isinstance(value, dict):
+        return {k: _sanitize_envelope(v, temp_root, k)
+                for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_envelope(v, temp_root, key) for v in value]
+    if isinstance(value, str) and key in {"file", "files", "before", "after"}:
+        return _path_under_temp(value, temp_root)
+    return value
+
 
 def _validate_args(tool_name, arguments, tool_defs):
     """Лишние параметры и enum — единая валидация для всех веток (L9)."""
@@ -299,7 +346,7 @@ def _validate_args(tool_name, arguments, tool_defs):
     return None
 
 
-def _result_from_proc(proc):
+def _result_from_proc(proc, temp_root=None):
     """L9-семантика результата: rc вне {0,1,2} (крах) или непарсящийся вывод
     — isError:true и БЕЗ сырого stdout/stderr: traceback может содержать
     цитаты входного текста и не должен доставляться как «успех»."""
@@ -318,6 +365,8 @@ def _result_from_proc(proc):
         envelope = parsed
     else:
         envelope = None
+    if envelope is not None:
+        envelope = _sanitize_envelope(envelope, temp_root)
     if proc.returncode not in (0, 1, 2):
         content = []
         if envelope is not None:
@@ -389,7 +438,7 @@ def call_tool(tool_name, arguments, tool_defs):
                                   stderr=subprocess.PIPE,
                                   timeout=CALL_TIMEOUT, encoding="utf-8",
                                   errors="replace")
-            result, _env = _result_from_proc(proc)
+            result, _env = _result_from_proc(proc, tmp)
             return result, None
         except UnicodeError as exc:
             return {"content": [{"type": "text",
@@ -432,7 +481,7 @@ def call_tool(tool_name, arguments, tool_defs):
                                  "text": "таймаут инструмента (%d с)"
                                          % CALL_TIMEOUT}],
                     "isError": True}, None
-        result, envelope = _result_from_proc(proc)
+        result, envelope = _result_from_proc(proc, tmp)
         if (tool_name == "humanizer_polish" and proc.returncode in (0, 1)
                 and envelope is not None):
             # Второй прогон без --json: сам нормализованный текст

--- a/src/humanizer_ru/polish.py
+++ b/src/humanizer_ru/polish.py
@@ -95,30 +95,32 @@ def _assert_safe_destination(path):
 
 
 def _safe_write_text(path, text):
-    """Write UTF-8 text through a private, atomic, symlink-safe temp file."""
+    """Write atomically; preserve existing permissions and reject symlinks.
+
+    Parent checks are best-effort, not protection against a concurrent rename
+    of a parent directory. New backup files keep mkstemp's private mode.
+    """
     dest = Path(path)
     _assert_safe_destination(dest)
     parent = dest.parent
+    mode = (dest.stat().st_mode & 0o777) if dest.exists() else 0o600
     fd, tmp_name = tempfile.mkstemp(
         prefix="." + dest.name + ".", suffix=".tmp", dir=str(parent))
     try:
-        mask = os.umask(0)
-        os.umask(mask)
-        mode = 0o666 & ~mask
-        try:
-            os.fchmod(fd, mode)
-        except AttributeError:  # pragma: no cover - Windows
-            os.chmod(tmp_name, mode)
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fd = None  # The stream now owns the descriptor, including on error.
             fh.write(text)
             fh.flush()
             os.fsync(fh.fileno())
+            if os.name != "nt":
+                os.fchmod(fh.fileno(), mode)
         os.replace(tmp_name, dest)
     except BaseException:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             os.unlink(tmp_name)
         except OSError:

--- a/src/humanizer_ru/polish.py
+++ b/src/humanizer_ru/polish.py
@@ -77,6 +77,53 @@ import json
 import os
 import re
 import sys
+import tempfile
+from pathlib import Path
+
+
+def _assert_safe_destination(path):
+    """Reject a destination or any parent that is a symbolic link."""
+    dest = Path(path)
+    probe = dest
+    while True:
+        if probe.is_symlink():
+            raise OSError("отказ писать через симлинк в цепочке: %s" % probe)
+        parent = probe.parent
+        if parent == probe:
+            break
+        probe = parent
+
+
+def _safe_write_text(path, text):
+    """Write UTF-8 text through a private, atomic, symlink-safe temp file."""
+    dest = Path(path)
+    _assert_safe_destination(dest)
+    parent = dest.parent
+    fd, tmp_name = tempfile.mkstemp(
+        prefix="." + dest.name + ".", suffix=".tmp", dir=str(parent))
+    try:
+        mask = os.umask(0)
+        os.umask(mask)
+        mode = 0o666 & ~mask
+        try:
+            os.fchmod(fd, mode)
+        except AttributeError:  # pragma: no cover - Windows
+            os.chmod(tmp_name, mode)
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, dest)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")
@@ -651,20 +698,17 @@ def main(argv=None) -> int:
                     # подмена (tmp + os.replace). Ошибка записи не оставляет
                     # частичный «успешный» результат: исходный файл цел,
                     # временный убирается, состояние уходит в errors с кодом 2.
-                    tmp = path + ".tmp-polish"
                     try:
-                        with open(path + ".bak", "w", encoding="utf-8",
-                                  newline="") as fh:
-                            fh.write(before)
-                        with open(tmp, "w", encoding="utf-8",
-                                  newline="") as fh:
-                            fh.write(after)
-                        os.replace(tmp, path)
+                        # Validate both destinations before touching the
+                        # backup, then use private mkstemp files for the
+                        # backup and replacement.  This prevents a
+                        # predictable temp path or symlink parent from
+                        # redirecting an in-place write.
+                        _assert_safe_destination(path)
+                        _assert_safe_destination(path + ".bak")
+                        _safe_write_text(path + ".bak", before)
+                        _safe_write_text(path, after)
                     except OSError as exc:
-                        try:
-                            os.unlink(tmp)
-                        except OSError:
-                            pass
                         print("НЕ ЗАПИСАНО %s: %r (исходный файл не изменён)"
                               % (path, exc), file=sys.stderr)
                         errors.append({"file": path, "error": repr(exc)})

--- a/src/humanizer_ru/text_layer.py
+++ b/src/humanizer_ru/text_layer.py
@@ -29,30 +29,32 @@ def _assert_safe_destination(path):
 
 
 def _safe_write_text(path, text):
-    """Write UTF-8 text through a private, atomic, symlink-safe temp file."""
+    """Write atomically; preserve existing permissions and reject symlinks.
+
+    Parent checks are best-effort, not protection against a concurrent rename
+    of a parent directory. New backup files keep mkstemp's private mode.
+    """
     dest = Path(path)
     _assert_safe_destination(dest)
     parent = dest.parent
+    mode = (dest.stat().st_mode & 0o777) if dest.exists() else 0o600
     fd, tmp_name = tempfile.mkstemp(
         prefix="." + dest.name + ".", suffix=".tmp", dir=str(parent))
     try:
-        mask = os.umask(0)
-        os.umask(mask)
-        mode = 0o666 & ~mask
-        try:
-            os.fchmod(fd, mode)
-        except AttributeError:  # pragma: no cover - Windows
-            os.chmod(tmp_name, mode)
         with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fd = None  # The stream now owns the descriptor, including on error.
             fh.write(text)
             fh.flush()
             os.fsync(fh.fileno())
+            if os.name != "nt":
+                os.fchmod(fh.fileno(), mode)
         os.replace(tmp_name, dest)
     except BaseException:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             os.unlink(tmp_name)
         except OSError:

--- a/src/humanizer_ru/text_layer.py
+++ b/src/humanizer_ru/text_layer.py
@@ -8,8 +8,56 @@
 снимаемые доказуемо безпотерно. Снятие детерминированное и проверяемое
 повторным прогоном детектора.
 """
+import os
 import re
+import tempfile
 import unicodedata
+from pathlib import Path
+
+
+def _assert_safe_destination(path):
+    """Reject a destination or any parent that is a symbolic link."""
+    dest = Path(path)
+    probe = dest
+    while True:
+        if probe.is_symlink():
+            raise OSError("отказ писать через симлинк в цепочке: %s" % probe)
+        parent = probe.parent
+        if parent == probe:
+            break
+        probe = parent
+
+
+def _safe_write_text(path, text):
+    """Write UTF-8 text through a private, atomic, symlink-safe temp file."""
+    dest = Path(path)
+    _assert_safe_destination(dest)
+    parent = dest.parent
+    fd, tmp_name = tempfile.mkstemp(
+        prefix="." + dest.name + ".", suffix=".tmp", dir=str(parent))
+    try:
+        mask = os.umask(0)
+        os.umask(mask)
+        mode = 0o666 & ~mask
+        try:
+            os.fchmod(fd, mode)
+        except AttributeError:  # pragma: no cover - Windows
+            os.chmod(tmp_name, mode)
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, dest)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
 
 _MARKER_CASES = {}
 _CM_IS_URL_MARKER = None
@@ -979,20 +1027,17 @@ def clean_main(argv=None) -> int:
                         # Атомарность: копия .bak, запись во временный файл
                         # и os.replace; ошибка записи оставляет исходный
                         # файл целым (состояние уходит в errors, код 2).
-                        tmp = path + ".tmp-clean"
                         try:
-                            with open(path + ".bak", "w", encoding="utf-8",
-                                      newline="") as fh:
-                                fh.write(before)
-                            with open(tmp, "w", encoding="utf-8",
-                                      newline="") as fh:
-                                fh.write(cleaned)
-                            os.replace(tmp, path)
+                            # Validate both destinations before touching the
+                            # backup, then use private mkstemp files for the
+                            # backup and replacement.  This prevents a
+                            # predictable temp path or symlink parent from
+                            # redirecting an in-place write.
+                            _assert_safe_destination(path)
+                            _assert_safe_destination(path + ".bak")
+                            _safe_write_text(path + ".bak", before)
+                            _safe_write_text(path, cleaned)
                         except OSError as exc:
-                            try:
-                                os.unlink(tmp)
-                            except OSError:
-                                pass
                             print("НЕ ЗАПИСАНО %s: %r (исходный файл не "
                                   "изменён)" % (path, exc), file=sys.stderr)
                             errors.append({"file": label,

--- a/tests/test_agent_contract_regressions.py
+++ b/tests/test_agent_contract_regressions.py
@@ -173,6 +173,10 @@ class CleanCliScenarioTests(unittest.TestCase):
     def test_in_place_writes_and_backs_up(self):
         work = os.path.join(TMP, "inplace.txt")
         shutil.copyfile(os.path.join(TMP, "art.txt"), work)
+        predictable_tmp = work + ".tmp-clean"
+        with open(predictable_tmp, "w", encoding="utf-8",
+                  newline="\n") as fh:
+            fh.write("sentinel")
         rc, out, _err = _run_entry("cli", "clean_main", ["--in-place",
                                                          "inplace.txt"])
         self.assertEqual(rc, 0)
@@ -181,6 +185,10 @@ class CleanCliScenarioTests(unittest.TestCase):
         self.assertNotIn(":contentReference", cleaned)
         with open(work + ".bak", encoding="utf-8") as fh:
             self.assertEqual(fh.read(), ART)
+        with open(predictable_tmp, encoding="utf-8") as fh:
+            self.assertEqual(fh.read(), "sentinel",
+                             "предсказуемый temp-файл не должен "
+                             "перезаписываться")
 
     def test_in_place_error_preserves_original(self):
         work = os.path.join(TMP, "blocked.txt")

--- a/tests/test_atomic_text_write.py
+++ b/tests/test_atomic_text_write.py
@@ -1,0 +1,65 @@
+"""Atomic UTF-8 writes preserve permissions and leave failures reversible."""
+import os
+from pathlib import Path
+import stat
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+if (ROOT / "src").is_dir():
+    sys.path.insert(0, str(ROOT / "src"))
+from humanizer_ru import polish, text_layer
+
+
+class AtomicTextWriteTests(unittest.TestCase):
+    def test_exact_bytes_and_permissions(self):
+        for module in (polish, text_layer):
+            with self.subTest(module=module.__name__), tempfile.TemporaryDirectory() as td:
+                target = Path(td) / "draft.txt"
+                target.write_bytes(b"original")
+                if os.name != "nt":
+                    target.chmod(0o600)
+                text = "RU: \u0442\u0435\u043a\u0441\u0442\r\nEN: text\n"
+                module._safe_write_text(target, text)
+                self.assertEqual(target.read_bytes(), text.encode("utf-8"))
+                if os.name != "nt":
+                    self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o600)
+                backup = Path(td) / "draft.txt.bak"
+                module._safe_write_text(backup, "original")
+                if os.name != "nt":
+                    self.assertEqual(stat.S_IMODE(backup.stat().st_mode), 0o600)
+                self.assertEqual({p.name for p in Path(td).iterdir()},
+                                 {"draft.txt", "draft.txt.bak"})
+
+    def test_replace_failure_keeps_original_and_removes_temp(self):
+        for module in (polish, text_layer):
+            with self.subTest(module=module.__name__), tempfile.TemporaryDirectory() as td:
+                target = Path(td) / "draft.txt"
+                target.write_bytes(b"original")
+                with mock.patch.object(module.os, "replace", side_effect=OSError("busy")):
+                    with self.assertRaises(OSError):
+                        module._safe_write_text(target, "replacement")
+                self.assertEqual(target.read_bytes(), b"original")
+                self.assertEqual(list(Path(td).iterdir()), [target])
+
+    @unittest.skipIf(os.name == "nt", "POSIX symlink fixtures; Windows needs elevated symlink rights")
+    def test_symlink_target_or_parent_is_rejected(self):
+        for module in (polish, text_layer):
+            with self.subTest(module=module.__name__), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                target = root / "original.txt"
+                target.write_bytes(b"original")
+                link = root / "link.txt"
+                link.symlink_to(target)
+                alias = root / "alias"
+                alias.symlink_to(root, target_is_directory=True)
+                for destination in (link, alias / target.name):
+                    with self.assertRaises(OSError):
+                        module._safe_write_text(destination, "replacement")
+                self.assertEqual(target.read_bytes(), b"original")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_demo_sharing.py
+++ b/tests/test_demo_sharing.py
@@ -46,15 +46,19 @@ const document = {
   createElement() { return { className: '', innerHTML: '', appendChild() {} }; },
   addEventListener(type, fn) { (documentHandlers[type] ||= []).push(fn); },
 };
-let hash = '';
+let hash = '#shared%20text';
 let hashWrites = 0;
+let replaceWrites = 0;
 const location = {
   pathname: '/', search: '',
   get hash() { return hash; },
   set hash(value) { hash = value && value[0] === '#' ? value : '#' + value; hashWrites++; },
 };
 const context = {
-  document, location, navigator: {}, history: { replaceState() {} },
+  document, location, navigator: {}, history: { replaceState(_a, _b, url) {
+    replaceWrites++;
+    hash = String(url).includes('#') ? String(url).slice(String(url).indexOf('#')) : '';
+  } },
   HUMANIZER_MARKERS: { rules: [] }, HUMANIZER_SAMPLE: '',
   TextEncoder, encodeURIComponent, decodeURIComponent, setTimeout, clearTimeout,
   console, JSON, Object, String, Array, RegExp, Error,
@@ -69,6 +73,10 @@ function click() { share.emit('click'); }
   // The page must reset it before every showModal() call.
   function escapeDialog() { dialog.emit('close'); }
 function result() {
+  const loaded = { text: text.value, hash };
+  text.value = 'edited shared text';
+  text.emit('input');
+  const edited = { text: text.value, hash, replaceWrites };
   text.value = '';
   click();
   const empty = { shown: dialog.shown, writes: hashWrites, hash };
@@ -96,8 +104,9 @@ function result() {
   const beforeMalformed = { shown: dialog.shown, writes: hashWrites, hash };
   click();
   const malformed = { shown: dialog.shown, writes: hashWrites, hash };
-  return { empty, pending, cancelled, confirmed, escaped, boundary, oversize,
-           beforeBoundary, beforeOversize, malformed, beforeMalformed };
+  return { loaded, edited, empty, pending, cancelled, confirmed, escaped,
+           boundary, oversize, beforeBoundary, beforeOversize, malformed,
+           beforeMalformed };
 }
 process.stdout.write(JSON.stringify(result()));
 """
@@ -117,6 +126,10 @@ class DemoSharingTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         data = json.loads(proc.stdout)
 
+        self.assertEqual(data["loaded"]["text"], "shared text")
+        self.assertEqual(data["edited"]["text"], "edited shared text")
+        self.assertEqual(data["edited"]["hash"], "")
+        self.assertEqual(data["edited"]["replaceWrites"], 1)
         self.assertEqual(data["empty"]["writes"], 0)
         self.assertEqual(data["empty"]["shown"], 0)
         self.assertEqual(data["pending"]["shown"], 1)

--- a/tests/test_mcp_conformance.py
+++ b/tests/test_mcp_conformance.py
@@ -302,16 +302,14 @@ class TestMcpTools(unittest.TestCase):
         for i, (name, arguments) in enumerate(calls, start=2):
             lines.append(_req(i, "tools/call", {
                 "name": name, "arguments": arguments}))
-        resps, _ = _session(lines)
+        resps, proc = _session(lines)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(len(resps), len(calls) + 1)
         for response, (name, _arguments) in zip(resps[1:], calls):
             with self.subTest(tool=name):
                 result = response["result"]
                 self.assertNotIn("mcp-tool-", json.dumps(result))
                 self.assertNotIn("mcp-facts-", json.dumps(result))
-                self.assertNotIn("AppData\\Local\\Temp",
-                                  json.dumps(result))
-                self.assertNotIn("C:\\\\Users\\vovap",
-                                  json.dumps(result))
                 envelope = result["structuredContent"]
                 if name in ("humanizer_facts",):
                     self.assertEqual(envelope["files"],

--- a/tests/test_mcp_conformance.py
+++ b/tests/test_mcp_conformance.py
@@ -281,6 +281,49 @@ class TestMcpTools(unittest.TestCase):
             self.schema_errors(r["structuredContent"],
                                self._schema("humanizer_report")), [])
 
+    def test_results_hide_host_temp_paths_for_all_tools(self):
+        """MCP metadata uses stable placeholders, while input text is intact."""
+        calls = [
+            ("humanizer_scan", {"text": "Обычный русский текст."}),
+            ("humanizer_markers", {
+                "text": "Согласно :contentReference[oaicite:1]{index=1}"}),
+            ("humanizer_polish", {"text": "Текст — с тире…"}),
+            ("humanizer_clean", {
+                "text": "Согласно :contentReference[oaicite:1]{index=1}"}),
+            ("humanizer_detect", {"text": "Обычный русский текст."}),
+            ("humanizer_facts", {
+                "text_before": "В 2024 году было 3 заявки.",
+                "text_after": "В 2025 году было 4 заявки."}),
+            ("humanizer_report", {
+                "text_before": "Короткий русский текст.",
+                "text_after": "Другой русский текст."}),
+        ]
+        lines = [_INIT]
+        for i, (name, arguments) in enumerate(calls, start=2):
+            lines.append(_req(i, "tools/call", {
+                "name": name, "arguments": arguments}))
+        resps, _ = _session(lines)
+        for response, (name, _arguments) in zip(resps[1:], calls):
+            with self.subTest(tool=name):
+                result = response["result"]
+                self.assertNotIn("mcp-tool-", json.dumps(result))
+                self.assertNotIn("mcp-facts-", json.dumps(result))
+                self.assertNotIn("AppData\\Local\\Temp",
+                                  json.dumps(result))
+                self.assertNotIn("C:\\\\Users\\vovap",
+                                  json.dumps(result))
+                envelope = result["structuredContent"]
+                if name in ("humanizer_facts",):
+                    self.assertEqual(envelope["files"],
+                                     ["<input.txt>", "<input.txt.after>"])
+                elif name == "humanizer_report":
+                    item = envelope["files"][0]
+                    self.assertEqual(item["before"], "<input.txt>")
+                    self.assertEqual(item["after"], "<input.txt.after>")
+                else:
+                    self.assertEqual(envelope["files"][0]["file"],
+                                     "<input.txt>")
+
     def test_marker_class_param(self):
         text = ":contentReference[oaicite:1]{index=1} и ассистентом\u200b"
         resps, _ = _session([_INIT, _req(2, "tools/call", {

--- a/tests/test_preservation_contract.py
+++ b/tests/test_preservation_contract.py
@@ -216,6 +216,10 @@ class CliPreservationTests(unittest.TestCase):
             path = os.path.join(td, "q.md")
             with open(path, "w", encoding="utf-8", newline="") as fh:
                 fh.write(DOC)
+            predictable_tmp = path + ".tmp-polish"
+            with open(predictable_tmp, "w", encoding="utf-8",
+                      newline="") as fh:
+                fh.write("sentinel")
             proc = subprocess.run(
                 [sys.executable, "-X", "utf8", self.POLISH, path,
                  "--in-place", "--typographic"],
@@ -228,8 +232,10 @@ class CliPreservationTests(unittest.TestCase):
                 bak = fh.read()
             self.assertEqual(bak, DOC)
             self.assertIn(URL, after)
-            self.assertNotIn(path + ".tmp-polish",
-                             json.dumps(os.listdir(td)))
+            with open(predictable_tmp, encoding="utf-8") as fh:
+                self.assertEqual(fh.read(), "sentinel",
+                                 "предсказуемый temp-файл не должен "
+                                 "перезаписываться")
             shutil.rmtree(td, ignore_errors=True)
 
 


### PR DESCRIPTION
Pasted text could remain in the share URL after editing, MCP metadata exposed host temporary paths, and CLI cleanup used predictable temporary filenames. This change clears stale fragments on edit, uses stable MCP metadata labels, and writes replacements through unique temporary files while preserving existing POSIX permissions. New backups are private on POSIX; parent symlink checks remain best-effort against concurrent directory changes.

The demo also gains readable dark-theme buttons and links, a visible keyboard focus outline, an accurate Clear field label, and no empty preview panel. The service-worker cache is regenerated for the updated assets.

Validation:
- Full strict suite: 156 gates passed, no skips.
- Unit suite: 485 tests, no failures, 13 environment-specific skips on Windows.
- Regression tests cover stale share fragments, MCP metadata for all seven tools, existing predictable-temp sentinels, failed replacement, file permissions, and POSIX symlinks (Linux CI).
- Manual browser check: editing a loaded shared text clears the fragment immediately and preserves the edited input; dark-theme controls and focus remain visible.
- Package mirrors checked both on disk and in the staged git index.
